### PR TITLE
Fixes utf8 encoding

### DIFF
--- a/generate_extensions.py
+++ b/generate_extensions.py
@@ -81,6 +81,12 @@ az:
 az-output-folder: $(azure-cli-extension-folder)/src/{file_name}
 python-sdk-output-folder: "$(az-output-folder)/azext_{file_name}/vendored_sdks/{file_name}"
 cli-core-lib: msgraph.cli.core
+
+directive:
+    - where:
+          group: ^{file_name}(.*)
+      set:
+          group: {file_name}
 ```
   """
     write_to('readme.az.md', config)

--- a/src/msgraph-cli-core/setup.py
+++ b/src/msgraph-cli-core/setup.py
@@ -44,6 +44,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
+    'sshtunnel',
     'argcomplete~=1.8',
     'azure-cli-telemetry',
     'azure-identity',


### PR DESCRIPTION
## Purpose

This PR fixes the cli from breaking when it receives non utf8 encoded characters.

## Notes

**msgraph-cli**  was  breaking when it received a response from `mg mail user list-messages` command.  The failure was due to a byte string in the response that could not be decoded with utf-8 coding format. Changes in this PR try to decode the byte string, if the decoding fails, it ignores the byte string.

