### PR TITLE
Add Help messages and Help loaders

### DIFF
--- a/msgraph/cli/core/__init__.py
+++ b/msgraph/cli/core/__init__.py
@@ -14,7 +14,6 @@ from knack.deprecation import Deprecated
 from knack import CLICommandsLoader, CLICommand, ArgumentsContext
 from knack.introspection import extract_args_from_signature, extract_full_summary_from_signature
 
-
 from msgraph.cli.core.commands._util import _load_module_command_loader, _load_extension_command_loader
 from msgraph.cli.core.invocation import GraphCliCommandInvoker
 from msgraph.cli.core.installed_extensions import installed_extensions
@@ -22,6 +21,7 @@ from msgraph.cli.core.commands import GraphCommandGroup, GraphCliCommand
 from msgraph.cli.core.commands._util import get_arg_list
 from msgraph.cli.core.commands.client_factory import resolve_client_arg_name
 from msgraph.cli.core.commands.parameters import GraphArgumentContext
+from ._help import GraphCliHelp
 from .commands.constants import EXCLUDED_PARAMS
 
 __version__ = '1.0.0'
@@ -129,11 +129,11 @@ class MainCommandsLoader(CLICommandsLoader):
 
 # This is the entry point into the Knack CLI framework.
 def get_default_cli():
-
     return CLI(
         cli_name='mg',
         commands_loader_cls=MainCommandsLoader,
-        invocation_cls=GraphCliCommandInvoker
+        invocation_cls=GraphCliCommandInvoker,
+        help_cls=GraphCliHelp,
     )
 
 

--- a/msgraph/cli/core/_help.py
+++ b/msgraph/cli/core/_help.py
@@ -1,0 +1,383 @@
+from __future__ import print_function
+import argparse
+
+from msgraph.cli.core.commands import ExtensionCommandSource
+from knack.help import (
+    HelpFile as KnackHelpFile, CommandHelpFile as KnackCommandHelpFile, GroupHelpFile as KnackGroupHelpFile,
+    HelpExample as KnackHelpExample, HelpParameter as KnackHelpParameter, _print_indent, CLIHelp, HelpAuthoringException
+)
+from knack.log import get_logger
+from knack.util import CLIError
+
+logger = get_logger(__name__)
+
+# TODO: Update https://aka.ms/microsoftgraph with a link to msgraph-cli commands
+PRIVACY_STATEMENT = """
+Welcome to Microsoft Graph CLI!
+---------------------
+Use `mg -h` to see available commands or go to https://aka.ms/microsoftgraph.
+
+Telemetry
+---------
+The Microsoft Graph CLI collects usage data in order to improve your experience.
+The data is anonymous and does not include commandline argument values.
+The data is collected by Microsoft.
+
+You can change your telemetry settings with `mg configure`.
+"""
+
+WELCOME_MESSAGE = r'''                                              
+
+___  ____                           __ _     _____                 _     
+|  \/  (_)                         / _| |   |  __ \               | |    
+| .  . |_  ___ _ __ ___  ___  ___ | |_| |_  | |  \/_ __ __ _ _ __ | |__  
+| |\/| | |/ __| '__/ _ \/ __|/ _ \|  _| __| | | __| '__/ _` | '_ \| '_ \ 
+| |  | | | (__| | | (_) \__ \ (_) | | | |_  | |_\ \ | | (_| | |_) | | | |
+\_|  |_/_|\___|_|  \___/|___/\___/|_|  \__|  \____/_|  \__,_| .__/|_| |_|
+                                                            | |          
+                                                            |_|          
+                                              
+Welcome to the Microsoft Graph CLI!
+
+Use mg --version to display the current version
+Here are the base commands
+'''
+
+# PrintMixin class to decouple printing functionality from GraphCliHelp class.
+# Most of these methods override print methods in CLIHelp.
+
+
+class CLIPrintMixin(CLIHelp):
+    def _print_header(self, cli_name, help_file):
+        super(CLIPrintMixin, self)._print_header(cli_name, help_file)
+
+        links = help_file.links
+        if links:
+            link_text = "{} and {}".format(", ".join([link["url"] for link in links[0:-1]]),
+                                           links[-1]["url"]) if len(links) > 1 else links[0]["url"]
+            link_text = "For more information, see: {}\n".format(link_text)
+            _print_indent(link_text, 2, width=self.textwrap_width)
+
+    def _print_detailed_help(self, cli_name, help_file):
+        CLIPrintMixin._print_extensions_msg(help_file)
+        super(CLIPrintMixin, self)._print_detailed_help(cli_name, help_file)
+        self._print_mg_find_message(help_file.command, self.cli_ctx.enable_color)
+
+    @staticmethod
+    def _get_choices_defaults_sources_str(p):
+        choice_str = '  Allowed values: {}.'.format(', '.join(sorted([str(x) for x in p.choices]))) \
+            if p.choices else ''
+        default_value_source = p.default_value_source if p.default_value_source else 'Default'
+        default_str = '  {}: {}.'.format(default_value_source, p.default) \
+            if p.default and p.default != argparse.SUPPRESS else ''
+        value_sources_str = CLIPrintMixin._process_value_sources(p) if p.value_sources else ''
+        return '{}{}{}'.format(choice_str, default_str, value_sources_str)
+
+    @staticmethod
+    def _print_examples(help_file):
+        indent = 0
+        _print_indent('Examples', indent)
+        for e in help_file.examples:
+            indent = 1
+            _print_indent('{0}'.format(e.short_summary), indent)
+            indent = 2
+            if e.long_summary:
+                _print_indent('{0}'.format(e.long_summary), indent)
+            _print_indent('{0}'.format(e.command), indent)
+            print('')
+
+    @staticmethod
+    def _print_mg_find_message(command, enable_color):
+        from colorama import Style
+        indent = 0
+        message = 'For more specific examples, use: mg find "mg {}"'.format(command)
+        if enable_color:
+            message = Style.BRIGHT + message + Style.RESET_ALL
+        _print_indent(message + '\n', indent)
+
+    @staticmethod
+    def _process_value_sources(p):
+        commands, strings, urls = [], [], []
+
+        for item in p.value_sources:
+            if "string" in item:
+                strings.append(item["string"])
+            elif "link" in item and "command" in item["link"]:
+                commands.append(item["link"]["command"])
+            elif "link" in item and "url" in item["link"]:
+                urls.append(item["link"]["url"])
+
+        command_str = '  Values from: {}.'.format(", ".join(commands)) if commands else ''
+        string_str = '  {}'.format(", ".join(strings)) if strings else ''
+        string_str = string_str + "." if string_str and not string_str.endswith(".") else string_str
+        urls_str = '  For more info, go to: {}.'.format(", ".join(urls)) if urls else ''
+        return '{}{}{}'.format(command_str, string_str, urls_str)
+
+    @staticmethod
+    def _print_extensions_msg(help_file):
+        if help_file.type != 'command':
+            return
+        if isinstance(help_file.command_source, ExtensionCommandSource):
+            logger.warning(help_file.command_source.get_command_warn_msg())
+
+            # Extension preview/experimental warning is disabled because it can be confusing when displayed together
+            # with command or command group preview/experimental warning. See #12556
+
+            # # If experimental is true, it overrides preview
+            # if help_file.command_source.experimental:
+            #     logger.warning(help_file.command_source.get_experimental_warn_msg())
+            # elif help_file.command_source.preview:
+            #     logger.warning(help_file.command_source.get_preview_warn_msg())
+
+
+class GraphCliHelp(CLIPrintMixin, CLIHelp):
+
+    def __init__(self, cli_ctx):
+        super(GraphCliHelp, self).__init__(cli_ctx,
+                                        privacy_statement=PRIVACY_STATEMENT,
+                                        welcome_message=WELCOME_MESSAGE,
+                                        command_help_cls=CliCommandHelpFile,
+                                        group_help_cls=CliGroupHelpFile,
+                                        help_cls=CliHelpFile)
+        from knack.help import HelpObject
+
+        # TODO: This workaround is used to avoid a bizarre bug in Python 2.7. It
+        # essentially reassigns Knack's HelpObject._normalize_text implementation
+        # with an identical implemenation in Az. For whatever reason, this fixes
+        # the bug in Python 2.7.
+        @staticmethod
+        def new_normalize_text(s):
+            if not s or len(s) < 2:
+                return s or ''
+            s = s.strip()
+            initial_upper = s[0].upper() + s[1:]
+            trailing_period = '' if s[-1] in '.!?' else '.'
+            return initial_upper + trailing_period
+
+        HelpObject._normalize_text = new_normalize_text  # pylint: disable=protected-access
+
+        self._register_help_loaders()
+        self._name_to_content = {}
+
+    def show_help(self, cli_name, nouns, parser, is_group):
+        self.update_loaders_with_help_file_contents(nouns)
+
+        delimiters = ' '.join(nouns)
+        help_file = self.command_help_cls(self, delimiters, parser) if not is_group \
+            else self.group_help_cls(self, delimiters, parser)
+        help_file.load(parser)
+        if not nouns:
+            help_file.command = ''
+        else:
+            GraphCliHelp.update_examples(help_file)
+        self._print_detailed_help(cli_name, help_file)
+        # TODO: Show updates available
+        show_link = self.cli_ctx.config.getboolean('output', 'show_survey_link', True)
+
+        # TODO: Show survey prompts
+        if show_link:
+            pass
+
+    def _register_help_loaders(self):
+        import msgraph.cli.core._help_loaders as help_loaders
+        import inspect
+
+        def is_loader_cls(cls):
+            return inspect.isclass(cls) and cls.__name__ != 'BaseHelpLoader' and issubclass(cls, help_loaders.BaseHelpLoader)  # pylint: disable=line-too-long
+
+        versioned_loaders = {}
+        for cls_name, loader_cls in inspect.getmembers(help_loaders, is_loader_cls):
+            loader = loader_cls(self)
+            versioned_loaders[cls_name] = loader
+
+        if len(versioned_loaders) != len({ldr.version for ldr in versioned_loaders.values()}):
+            ldrs_str = " ".join("{}-version:{}".format(cls_name, ldr.version) for cls_name, ldr in versioned_loaders.items())  # pylint: disable=line-too-long
+            raise CLIError("Two loaders have the same version. Loaders:\n\t{}".format(ldrs_str))
+
+        self.versioned_loaders = versioned_loaders
+
+    def update_loaders_with_help_file_contents(self, nouns):
+        loader_file_names_dict = {}
+        file_name_set = set()
+        for ldr_cls_name, loader in self.versioned_loaders.items():
+            new_file_names = loader.get_noun_help_file_names(nouns) or []
+            loader_file_names_dict[ldr_cls_name] = new_file_names
+            file_name_set.update(new_file_names)
+
+        for file_name in file_name_set:
+            if file_name not in self._name_to_content:
+                with open(file_name, 'r') as f:
+                    self._name_to_content[file_name] = f.read()
+
+        for ldr_cls_name, file_names in loader_file_names_dict.items():
+            file_contents = {}
+            for name in file_names:
+                file_contents[name] = self._name_to_content[name]
+            self.versioned_loaders[ldr_cls_name].update_file_contents(file_contents)
+
+    # This method is meant to be a hook that can be overridden by an extension or module.
+    @staticmethod
+    def update_examples(help_file):
+        pass
+
+
+class CliHelpFile(KnackHelpFile):
+
+    def __init__(self, help_ctx, delimiters):
+        # Each help file (for a command or group) has a version denoting the source of its data.
+        super(CliHelpFile, self).__init__(help_ctx, delimiters)
+        self.links = []
+
+    def _should_include_example(self, ex):
+        supported_profiles = ex.get('supported-profiles')
+        unsupported_profiles = ex.get('unsupported-profiles')
+
+        if all((supported_profiles, unsupported_profiles)):
+            raise HelpAuthoringException("An example cannot have both supported-profiles and unsupported-profiles.")
+
+        if supported_profiles:
+            supported_profiles = [profile.strip() for profile in supported_profiles.split(',')]
+            return self.help_ctx.cli_ctx.cloud.profile in supported_profiles
+
+        if unsupported_profiles:
+            unsupported_profiles = [profile.strip() for profile in unsupported_profiles.split(',')]
+            return self.help_ctx.cli_ctx.cloud.profile not in unsupported_profiles
+
+        return True
+
+    # Needs to override base implementation to exclude unsupported examples.
+    def _load_from_data(self, data):
+        if not data:
+            return
+
+        if isinstance(data, str):
+            self.long_summary = data
+            return
+
+        if 'type' in data:
+            self.type = data['type']
+
+        if 'short-summary' in data:
+            self.short_summary = data['short-summary']
+
+        self.long_summary = data.get('long-summary')
+
+        if 'examples' in data:
+            self.examples = []
+            for d in data['examples']:
+                if self._should_include_example(d):
+                    self.examples.append(HelpExample(**d))
+
+    def load(self, options):
+        ordered_loaders = sorted(self.help_ctx.versioned_loaders.values(), key=lambda ldr: ldr.version)
+        for loader in ordered_loaders:
+            loader.versioned_load(self, options)
+
+
+class CliGroupHelpFile(KnackGroupHelpFile, CliHelpFile):
+
+    def load(self, options):
+        # forces class to use this load method even if KnackGroupHelpFile overrides CliHelpFile's method.
+        CliHelpFile.load(self, options)
+
+
+class CliCommandHelpFile(KnackCommandHelpFile, CliHelpFile):
+
+    def __init__(self, help_ctx, delimiters, parser):
+        super(CliCommandHelpFile, self).__init__(help_ctx, delimiters, parser)
+        self.type = 'command'
+        self.command_source = getattr(parser, 'command_source', None)
+
+        self.parameters = []
+
+        for action in [a for a in parser._actions if a.help != argparse.SUPPRESS]:  # pylint: disable=protected-access
+            if action.option_strings:
+                self._add_parameter_help(action)
+            else:
+                # use metavar for positional parameters
+                param_kwargs = {
+                    'name_source': [action.metavar or action.dest],
+                    'deprecate_info': getattr(action, 'deprecate_info', None),
+                    'preview_info': getattr(action, 'preview_info', None),
+                    'experimental_info': getattr(action, 'experimental_info', None),
+                    'default_value_source': getattr(action, 'default_value_source', None),
+                    'description': action.help,
+                    'choices': action.choices,
+                    'required': False,
+                    'default': None,
+                    'group_name': 'Positional'
+                }
+                self.parameters.append(HelpParameter(**param_kwargs))
+
+        help_param = next(p for p in self.parameters if p.name == '--help -h')
+        help_param.group_name = 'Global Arguments'
+
+        # update parameter type so we can use overriden update_from_data method to update value sources.
+        for param in self.parameters:
+            param.__class__ = HelpParameter
+
+    def _load_from_data(self, data):
+        super(CliCommandHelpFile, self)._load_from_data(data)
+
+        if isinstance(data, str) or not self.parameters or not data.get('parameters'):
+            return
+
+        loaded_params = []
+        loaded_param = {}
+        for param in self.parameters:
+            loaded_param = next((n for n in data['parameters'] if n['name'] == param.name), None)
+            if loaded_param:
+                param.update_from_data(loaded_param)
+            loaded_params.append(param)
+
+        self.parameters = loaded_params
+
+    def load(self, options):
+        # forces class to use this load method even if KnackCommandHelpFile overrides CliHelpFile's method.
+        CliHelpFile.load(self, options)
+
+
+class HelpExample(KnackHelpExample):  # pylint: disable=too-few-public-methods
+
+    def __init__(self, **_data):
+        # Old attributes
+        _data['name'] = _data.get('name', '')
+        _data['text'] = _data.get('text', '')
+        super(HelpExample, self).__init__(_data)
+
+        self.name = _data.get('summary', '') if _data.get('summary', '') else self.name
+        self.text = _data.get('command', '') if _data.get('command', '') else self.text
+
+        self.long_summary = _data.get('description', '')
+        self.supported_profiles = _data.get('supported-profiles', None)
+        self.unsupported_profiles = _data.get('unsupported-profiles', None)
+
+    # alias old params with new
+    @property
+    def short_summary(self):
+        return self.name
+
+    @short_summary.setter
+    def short_summary(self, value):
+        self.name = value
+
+    @property
+    def command(self):
+        return self.text
+
+    @command.setter
+    def command(self, value):
+        self.text = value
+
+
+class HelpParameter(KnackHelpParameter):  # pylint: disable=too-many-instance-attributes
+
+    def __init__(self, **kwargs):
+        super(HelpParameter, self).__init__(**kwargs)
+
+    def update_from_data(self, data):
+        super(HelpParameter, self).update_from_data(data)
+        # original help.py value_sources are strings, update command strings to value-source dict
+        if self.value_sources:
+            self.value_sources = [str_or_dict if isinstance(str_or_dict, dict) else {"link": {"command": str_or_dict}}
+                                  for str_or_dict in self.value_sources]

--- a/msgraph/cli/core/_help_loaders.py
+++ b/msgraph/cli/core/_help_loaders.py
@@ -1,0 +1,235 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import abc
+import os
+import yaml
+
+from msgraph.cli.core._help import (HelpExample, CliHelpFile)
+
+from knack.util import CLIError
+from knack.log import get_logger
+
+logger = get_logger(__name__)
+
+try:
+    ABC = abc.ABC
+except AttributeError:  # Python 2.7, abc exists, but not ABC
+    ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})
+
+
+# BaseHelpLoader defining versioned loader interface. Also contains some helper methods.
+class BaseHelpLoader(ABC):
+    def __init__(self, help_ctx=None):
+        self.help_ctx = help_ctx
+        self._entry_data = None
+        self._file_content_dict = {}
+
+    def versioned_load(self, help_obj, parser):
+        if not self._file_content_dict:
+            return
+        self._entry_data = None
+        # Cycle through versioned_load helpers
+        self.load_entry_data(help_obj, parser)
+        if self._data_is_applicable():
+            self.load_help_body(help_obj)
+            self.load_help_parameters(help_obj)
+            self.load_help_examples(help_obj)
+        self._entry_data = None
+
+    def update_file_contents(self, file_contents):
+        self._file_content_dict.update(file_contents)
+
+    @abc.abstractmethod
+    def get_noun_help_file_names(self, nouns):
+        pass
+
+    @property
+    @abc.abstractmethod
+    def version(self):
+        pass
+
+    def _data_is_applicable(self):
+        return self._entry_data and self.version == self._entry_data.get('version')
+
+    @abc.abstractmethod
+    def load_entry_data(self, help_obj, parser):
+        pass
+
+    @abc.abstractmethod
+    def load_help_body(self, help_obj):
+        pass
+
+    @abc.abstractmethod
+    def load_help_parameters(self, help_obj):
+        pass
+
+    @abc.abstractmethod
+    def load_help_examples(self, help_obj):
+        pass
+
+    # Loader static helper methods
+
+    # Update a help file object from a data dict using the attribute to key mapping
+    @staticmethod
+    def _update_obj_from_data_dict(obj, data, attr_key_tups):
+        for attr, key in attr_key_tups:
+            try:
+                setattr(obj, attr, data[key] or attr)
+            except (AttributeError, KeyError):
+                pass
+
+    # update relevant help file object parameters from data.
+    @staticmethod
+    def _update_help_obj_params(help_obj, data_params, params_equal, attr_key_tups):
+        loaded_params = []
+        for param_obj in help_obj.parameters:
+            loaded_param = next((n for n in data_params if params_equal(param_obj, n)), None)
+            if loaded_param:
+                BaseHelpLoader._update_obj_from_data_dict(param_obj, loaded_param, attr_key_tups)
+            loaded_params.append(param_obj)
+        help_obj.parameters = loaded_params
+
+
+class YamlLoaderMixin(object):  # pylint:disable=too-few-public-methods
+    """A class containing helper methods for Yaml Loaders."""
+
+    # get the list of yaml help file names for the command or group
+    @staticmethod
+    def _get_yaml_help_files_list(nouns, cmd_loader_map_ref):
+        import inspect
+
+        command_nouns = " ".join(nouns)
+        # if command in map, get the loader. Path of loader is path of helpfile.
+        ldr_or_none = cmd_loader_map_ref.get(command_nouns, [None])[0]
+        if ldr_or_none:
+            loaders = {ldr_or_none}
+        else:
+            loaders = set()
+
+        # otherwise likely a group, try to find all command loaders under group as the group help could be defined
+        # in either.
+        if not loaders:
+            for cmd_name, cmd_ldr in cmd_loader_map_ref.items():
+                # if first word in loader name is the group, this is a command in the command group
+                if cmd_name.startswith(command_nouns + " "):
+                    loaders.add(cmd_ldr[0])
+
+        results = []
+        if loaders:
+            for loader in loaders:
+                loader_file_path = inspect.getfile(loader.__class__)
+                dir_name = os.path.dirname(loader_file_path)
+                files = os.listdir(dir_name)
+                for file in files:
+                    if file.endswith("help.yaml") or file.endswith("help.yml"):
+                        help_file_path = os.path.join(dir_name, file)
+                        results.append(help_file_path)
+        return results
+
+    @staticmethod
+    def _parse_yaml_from_string(text, help_file_path):
+        dir_name, base_name = os.path.split(help_file_path)
+        pretty_file_path = os.path.join(os.path.basename(dir_name), base_name)
+
+        if not text:
+            raise CLIError("No content passed for {}.".format(pretty_file_path))
+
+        try:
+            return yaml.safe_load(text)
+        except yaml.YAMLError as e:
+            raise CLIError("Error parsing {}:\n\n{}".format(pretty_file_path, e))
+
+
+class HelpLoaderV0(BaseHelpLoader):
+
+    @property
+    def version(self):
+        return 0
+
+    def versioned_load(self, help_obj, parser):
+        super(CliHelpFile, help_obj).load(parser)  # pylint:disable=bad-super-call
+
+    def get_noun_help_file_names(self, nouns):
+        pass
+
+    def load_entry_data(self, help_obj, parser):
+        pass
+
+    def load_help_body(self, help_obj):
+        pass
+
+    def load_help_parameters(self, help_obj):
+        pass
+
+    def load_help_examples(self, help_obj):
+        pass
+
+
+class HelpLoaderV1(BaseHelpLoader, YamlLoaderMixin):
+    core_attrs_to_keys = [("short_summary", "summary"), ("long_summary", "description")]
+    body_attrs_to_keys = core_attrs_to_keys + [("links", "links")]
+    param_attrs_to_keys = core_attrs_to_keys + [("value_sources", "value-sources")]
+
+    @property
+    def version(self):
+        return 1
+
+    def get_noun_help_file_names(self, nouns):
+        cmd_loader_map_ref = self.help_ctx.cli_ctx.invocation.commands_loader.cmd_to_loader_map
+        return self._get_yaml_help_files_list(nouns, cmd_loader_map_ref)
+
+    def update_file_contents(self, file_contents):
+        for file_name in file_contents:
+            if file_name not in self._file_content_dict:
+                data_dict = {file_name: self._parse_yaml_from_string(file_contents[file_name], file_name)}
+                self._file_content_dict.update(data_dict)
+
+    def load_entry_data(self, help_obj, parser):
+        prog = parser.prog if hasattr(parser, "prog") else parser._prog_prefix  # pylint: disable=protected-access
+        command_nouns = prog.split()[1:]
+        cmd_loader_map_ref = self.help_ctx.cli_ctx.invocation.commands_loader.cmd_to_loader_map
+
+        files_list = self._get_yaml_help_files_list(command_nouns, cmd_loader_map_ref)
+        data_list = [self._file_content_dict[name] for name in files_list]
+
+        self._entry_data = self._get_entry_data(help_obj.command, data_list)
+
+    def load_help_body(self, help_obj):
+        help_obj.long_summary = ""  # similar to knack...
+        self._update_obj_from_data_dict(help_obj, self._entry_data, self.body_attrs_to_keys)
+
+    def load_help_parameters(self, help_obj):
+        def params_equal(param, param_dict):
+            if param_dict['name'].startswith("--"):  # for optionals, help file name must be one of the  long options
+                return param_dict['name'] in param.name.split()
+            # for positionals, help file must name must match param name shown when -h is run
+            return param_dict['name'] == param.name
+
+        if help_obj.type == "command" and hasattr(help_obj, "parameters") and self._entry_data.get("arguments"):
+            loaded_params = []
+            for param_obj in help_obj.parameters:
+                loaded_param = next((n for n in self._entry_data["arguments"] if params_equal(param_obj, n)), None)
+                if loaded_param:
+                    self._update_obj_from_data_dict(param_obj, loaded_param, self.param_attrs_to_keys)
+                loaded_params.append(param_obj)
+            help_obj.parameters = loaded_params
+
+    def load_help_examples(self, help_obj):
+        if help_obj.type == "command" and self._entry_data.get("examples"):
+            help_obj.examples = [HelpExample(**ex) for ex in self._entry_data["examples"] if help_obj._should_include_example(ex)]  # pylint: disable=line-too-long, protected-access
+
+    @staticmethod
+    def _get_entry_data(cmd_name, data_list):
+        for data in data_list:
+            if data and data.get("content"):
+                try:
+                    entry_data = next(value for elem in data.get("content")
+                                      for key, value in elem.items() if value.get("name") == cmd_name)
+                    entry_data["version"] = data['version']
+                    return entry_data
+                except StopIteration:
+                    continue
+        return None

--- a/msgraph/cli/core/commands/__init__.py
+++ b/msgraph/cli/core/commands/__init__.py
@@ -23,7 +23,6 @@ class CliCommandType(object):
             self.settings.update(**other.settings)
         self.settings.update(**kwargs)
 
-
 class GraphCommandGroup(CommandGroup):
     def __init__(self, command_loader, group_name, **kwargs):
         merged_kwargs = self._merge_kwargs(
@@ -147,3 +146,35 @@ class GraphCliCommand(CLICommand):
 
     def __call__(self, *args, **kwargs):
         return self.handler(*args, **kwargs)
+
+
+class ExtensionCommandSource:
+    '''Class for commands contributed by an extension'''
+
+    def __init__(self, overrides_command=False, extension_name=None, preview=False, experimental=False):
+        super(ExtensionCommandSource, self).__init__()
+        # True if the command overrides a CLI command
+        self.overrides_command = overrides_command
+        self.extension_name = extension_name
+        self.preview = preview
+        self.experimental = experimental
+
+    def get_command_warn_msg(self):
+        if self.overrides_command:
+            if self.extension_name:
+                return 'The behavior of this command has been altered by the following extension: '\
+                    '{}'.format(self.extension_name)
+            return 'The behavior of this command has been altered by an extension'
+        if self.extension_name:
+            return 'This command is from the following extension: {}'.format(self.extension_name)
+        return 'This command is from an extension.'
+
+    def get_preview_warn_msg(self):
+        if self.preview:
+            return 'The extension is in preview'
+        return None
+
+    def get_experimental_warn_msg(self):
+        if self.experimental:
+            return 'The extension is experimental and not covered by customer support. '\
+                'Please use with discretion'

--- a/msgraph/cli/core/invocation.py
+++ b/msgraph/cli/core/invocation.py
@@ -113,7 +113,8 @@ class GraphCliCommandInvoker(CommandInvoker):
 
         arg_check = [a for a in args if a not in ['--debug', '--verbose']]
         if not arg_check:
-            self.parser.enable_autocomplete()
+            # TODO: Enable autocomplete
+            # self.parser.enable_autocomplete()
             subparser = self.parser.subparsers[tuple()]
             self.help.show_welcome(subparser)
             return CommandResultItem(None, exit_code=0)


### PR DESCRIPTION
## Overview
This PR introduces **Help** classes that are invoked when users use the **-h** flag and shows a welcome message and available sets of command groups when `mg` is run without specifying a command group.

## Notes
These changes have been extracted from Azure CLI *AS IS* with few modifications.