### PR TITLE
Feat/show warning message

### DIFF
--- a/graph
+++ b/graph
@@ -1,1 +1,1 @@
-python -m msgraph.cli
+python -m msgraph.cli $@

--- a/msgraph/cli/core/authentication.py
+++ b/msgraph/cli/core/authentication.py
@@ -22,9 +22,7 @@ class Authentication:
 
             self._save_auth_record(auth_record)
             return True
-
-        # get_credential will throw an error if the host OS doesn't have PyGObject installed
-        except:
+        except ValueError:
             warning = '''
             Token can't be stored securely. Install PyGObject to store token securely.
 
@@ -39,6 +37,8 @@ class Authentication:
         self._delete_auth_record()
 
     def get_credential(self, auth_record=None) -> InteractiveBrowserCredential:
+        '''Throws a ValueError exception if the host OS doesn't have PyGObject installed
+        '''
         return InteractiveBrowserCredential(
             client_id=CLIENT_ID,
             enable_persistent_cache=True,

--- a/msgraph/cli/core/authentication.py
+++ b/msgraph/cli/core/authentication.py
@@ -12,30 +12,33 @@ from msgraph.cli.core.exceptions import CLIException
 
 
 class Authentication:
-    def login(self, scopes: [str], encrypt_cache=False) -> bool:
-        credential = self.get_credential(encrypt_cache=encrypt_cache)
+    def login(self, scopes: [str]) -> bool:
+        auth_record = None
 
         try:
+            credential = self.get_credential()
             auth_record = credential.authenticate(scopes=scopes)
+        except:
+            print('Token stored in a plain text file, install PyGObject to encrypt token')
+            
+            credential = self.get_credential(unencrypt_cache=True)
+            auth_record = credential.authenticate(scopes=scopes)
+        
+        if auth_record is None:
+            return False
 
-            if auth_record is None:
-                return False
-
-            self._save_auth_record(auth_record)
-            return True
-        except Exception:
-            print('Token stored in a plain text file, install python3-gi to encrypt token')
-            self.login(scopes, encrypt_cache=True)
+        self._save_auth_record(auth_record)
+        return True
 
     def logout(self):
         # By deleting the authentication record, we logout the user
         self._delete_auth_record()
 
-    def get_credential(self, auth_record=None, encrypt_cache=False) -> InteractiveBrowserCredential:
+    def get_credential(self, auth_record=None, unencrypt_cache=False) -> InteractiveBrowserCredential:
         return InteractiveBrowserCredential(
             client_id=CLIENT_ID,
             enable_persistent_cache=True,
-            allow_unencrypted_cache=encrypt_cache,
+            allow_unencrypted_cache=unencrypt_cache,
             authentication_record=auth_record,
         )
 

--- a/msgraph/cli/core/authentication.py
+++ b/msgraph/cli/core/authentication.py
@@ -37,7 +37,11 @@ class Authentication:
         self._delete_auth_record()
 
     def get_credential(self, auth_record=None) -> InteractiveBrowserCredential:
-        '''Throws a ValueError exception if the host OS doesn't have PyGObject installed
+        '''
+        Raises
+        ------
+        ValueError
+            If PyGObject is not installed in the host Linux OS.
         '''
         return InteractiveBrowserCredential(
             client_id=CLIENT_ID,

--- a/msgraph/cli/core/authentication.py
+++ b/msgraph/cli/core/authentication.py
@@ -13,32 +13,36 @@ from msgraph.cli.core.exceptions import CLIException
 
 class Authentication:
     def login(self, scopes: [str]) -> bool:
-        auth_record = None
-
         try:
             credential = self.get_credential()
             auth_record = credential.authenticate(scopes=scopes)
-        except:
-            print('Token stored in a plain text file, install PyGObject to encrypt token')
-            
-            credential = self.get_credential(unencrypt_cache=True)
-            auth_record = credential.authenticate(scopes=scopes)
-        
-        if auth_record is None:
-            return False
 
-        self._save_auth_record(auth_record)
-        return True
+            if auth_record is None:
+                return False
+
+            self._save_auth_record(auth_record)
+            return True
+
+        # get_credential will throw an error if the host OS doesn't have PyGObject installed
+        except:
+            warning = '''
+            Token can't be stored securely. Install PyGObject to store token securely.
+
+            sudo apt install libgirepository1.0-dev libcairo2-dev python3-dev gir1.2-secret-1
+            pip install pygobject
+            '''
+            print(warning)
+            return False
 
     def logout(self):
         # By deleting the authentication record, we logout the user
         self._delete_auth_record()
 
-    def get_credential(self, auth_record=None, unencrypt_cache=False) -> InteractiveBrowserCredential:
+    def get_credential(self, auth_record=None) -> InteractiveBrowserCredential:
         return InteractiveBrowserCredential(
             client_id=CLIENT_ID,
             enable_persistent_cache=True,
-            allow_unencrypted_cache=unencrypt_cache,
+            allow_unencrypted_cache=False,
             authentication_record=auth_record,
         )
 

--- a/msgraph/cli/core/commands/client_factory.py
+++ b/msgraph/cli/core/commands/client_factory.py
@@ -36,7 +36,9 @@ def resolve_client_arg_name(operation, kwargs):
 
 def get_mgmt_service_client(cli_ctx, client_type, **kwargs):
 
-    credential = Authentication().get_credential()
+    auth = Authentication()
+    record = auth.get_auth_record()
+    credential = auth.get_credential(auth_record=record)
     graph_session = GraphSession(credential=credential)
 
     client = client_type({}, session=graph_session)


### PR DESCRIPTION
## Overview

Lets the user know when the **access-token** is **stored**  in **plain text**
### Demo

![image](https://user-images.githubusercontent.com/12011447/97152546-1fb3da80-1782-11eb-8f7c-e7aae5959092.png)

### Notes

N/A

## Testing Instructions

* Pull these changes
* Run `./graph login --scopes user.read ` in  **wsl** or **Ubuntu**
* Observe the warning message

Fixes #24 