### PR TITLE
Move cloud commands to profile command group

### DIFF
--- a/msgraph/cli/__main__.py
+++ b/msgraph/cli/__main__.py
@@ -5,13 +5,27 @@
 # --------------------------------------------------------------------------
 
 import sys
+from os import path
 
 from msgraph.cli.core import get_default_cli
+from msgraph.cli.core.constants import DEFAULT_CLOUDS, PROFILE_LOCATION
+from msgraph.cli.core.profile import write_profile
 
 mg_cli = get_default_cli()
 
+# Check if a profile exists, if not create one
+
+
+def create_profile_if_none_exists():
+    has_profile = path.exists(PROFILE_LOCATION)
+
+    if not has_profile:
+        profile = {'cloud': DEFAULT_CLOUDS['PUBLIC'], 'version': 'v1.0', 'user_defined_clouds': []}
+        write_profile(profile, error_msg='An error occured while creating your profile')
+
 
 def cli_main(cli, args):
+    create_profile_if_none_exists()
     return cli.invoke(args)
 
 

--- a/msgraph/cli/__main__.py
+++ b/msgraph/cli/__main__.py
@@ -13,9 +13,8 @@ from msgraph.cli.core.profile import write_profile
 
 mg_cli = get_default_cli()
 
+
 # Check if a profile exists, if not create one
-
-
 def create_profile_if_none_exists():
     has_profile = path.exists(PROFILE_LOCATION)
 

--- a/msgraph/cli/__main__.py
+++ b/msgraph/cli/__main__.py
@@ -5,13 +5,18 @@
 # --------------------------------------------------------------------------
 
 import sys
+import json
 from os import path
 
+from knack.cli import logger
+from colorama import init, Fore
+
 from msgraph.cli.core import get_default_cli
-from msgraph.cli.core.constants import DEFAULT_CLOUDS, PROFILE_LOCATION
+from msgraph.cli.core.constants import DEFAULT_PROFILE, PROFILE_LOCATION
 from msgraph.cli.core.profile import write_profile
 
 mg_cli = get_default_cli()
+init(autoreset=True)
 
 
 # Check if a profile exists, if not create one
@@ -19,8 +24,21 @@ def create_profile_if_none_exists():
     has_profile = path.exists(PROFILE_LOCATION)
 
     if not has_profile:
-        profile = {'cloud': DEFAULT_CLOUDS['PUBLIC'], 'version': 'v1.0', 'user_defined_clouds': []}
-        write_profile(profile, error_msg='An error occured while creating your profile')
+        write_profile(DEFAULT_PROFILE, error_msg='An error occured while creating your profile')
+        # Let the user know we have created a default profile for them
+        show_profile_msg()
+
+
+def show_profile_msg():
+    msg = f'''
+You're using the default profile
+
+CLOUD: {DEFAULT_PROFILE['cloud']}
+VERSION: {DEFAULT_PROFILE['version']}
+
+Run mg profile -h for profile commands
+        '''
+    print(Fore.YELLOW + msg)
 
 
 def cli_main(cli, args):

--- a/msgraph/cli/__main__.py
+++ b/msgraph/cli/__main__.py
@@ -5,10 +5,8 @@
 # --------------------------------------------------------------------------
 
 import sys
-import json
 from os import path
 
-from knack.cli import logger
 from colorama import init, Fore
 
 from msgraph.cli.core import get_default_cli
@@ -26,10 +24,10 @@ def create_profile_if_none_exists():
     if not has_profile:
         write_profile(DEFAULT_PROFILE, error_msg='An error occured while creating your profile')
         # Let the user know we have created a default profile for them
-        show_profile_msg()
+        show_default_profile_msg()
 
 
-def show_profile_msg():
+def show_default_profile_msg():
     msg = f'''
 You're using the default profile
 

--- a/msgraph/cli/core/commands/client_factory.py
+++ b/msgraph/cli/core/commands/client_factory.py
@@ -53,13 +53,8 @@ def _get_base_url():
 
 
 def _get_endpoint():
-    result = None
     cloud = read_profile().get('cloud', DEFAULT_BASE_URL)
-
-    if cloud:
-        return cloud.get('graph_endpoint')
-
-    return cloud
+    return cloud.get('graph_endpoint')
 
 
 def _get_version():

--- a/msgraph/cli/core/constants.py
+++ b/msgraph/cli/core/constants.py
@@ -55,3 +55,5 @@ DEFAULT_CLOUDS = {
         'azure_ad_endpoint': 'https://login.chinacloudapi.cn'
     }
 }
+
+DEFAULT_PROFILE = {'cloud': DEFAULT_CLOUDS['PUBLIC'], 'version': 'v1.0', 'user_defined_clouds': []}

--- a/msgraph/command_modules/profile/__init__.py
+++ b/msgraph/command_modules/profile/__init__.py
@@ -19,16 +19,13 @@ class ProfileCommandsLoader(AzCommandsLoader):
         # operations_tmpl is the file that contains the implementation of the command
         command_type = CliCommandType(operations_tmpl='msgraph.command_modules.profile.custom#{}',
                                       exception_handler=profile_exception_handler)
-        with self.command_group('cloud', command_type) as group:
-            group.command('select', 'select_cloud')
-            group.command('add', 'add_cloud')
-            group.command('show-current', 'current_cloud')
-            group.command('update', 'update_cloud')
-            group.command('delete', 'delete_cloud')
-
-        with self.command_group('graph-version', command_type) as group:
-            group.command('select', 'select_version')
-            group.command('show-current', 'show_version')
+        with self.command_group('profile', command_type) as group:
+            group.command('select-cloud', 'select_cloud')
+            group.command('add-cloud', 'add_cloud')
+            group.command('update-cloud', 'update_cloud')
+            group.command('delete-cloud', 'delete_cloud')
+            group.command('select-version', 'select_version')
+            group.command('show-profile', 'show_profile')
 
         return self.command_table
 

--- a/msgraph/command_modules/profile/_help.py
+++ b/msgraph/command_modules/profile/_help.py
@@ -4,27 +4,22 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 from knack.help_files import helps
-helps['graph-version select'] = """
+helps['profile select-version'] = """
 type: command
 short-summary: Select a graph-version from supported versions.
 """
 
-helps['graph-version show-current'] = """
-type: command
-short-summary: Show current graph-version
-"""
-
-helps['cloud select'] = """
+helps['profile select-cloud'] = """
 type: command
 short-summary: Select a cloud from supported clouds.
 """
 
-helps['cloud show-current'] = """
+helps['profile show-profile'] = """
 type: command
-short-summary: Show current cloud
+short-summary: Show profile information
 """
 
-helps['cloud delete'] = """
+helps['profile delete-cloud'] = """
 type: command
 short-summary: Deletes a user defined cloud
 parameters:
@@ -37,7 +32,7 @@ examples:
       mg cloud delete --name CUSTOM_CLOUD
 """
 
-helps['cloud add'] = """
+helps['profile add-cloud'] = """
 type: command
 short-summary: Add a custom cloud
 parameters:
@@ -56,7 +51,7 @@ examples:
       mg cloud add --name CUSTOM_CLOUD --endpoint https://graph.microsoft.com --authority https://graph.microsoftonline.com
 """
 
-helps['cloud update'] = """
+helps['profile update-cloud'] = """
 type: command
 short-summary: update a user defined cloud
 parameters:

--- a/msgraph/command_modules/profile/_help.py
+++ b/msgraph/command_modules/profile/_help.py
@@ -4,6 +4,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 from knack.help_files import helps
+
 helps['profile select-version'] = """
 type: command
 short-summary: Select a graph-version from supported versions.

--- a/msgraph/command_modules/profile/custom.py
+++ b/msgraph/command_modules/profile/custom.py
@@ -88,13 +88,9 @@ def select_version():
 
 def show_profile():
     profile = read_profile()
-
-    if len(profile) == 0:
-        profile = {'cloud': DEFAULT_CLOUDS.get('PUBLIC'), 'version': 'v1.0'}
-    else:
-        # remove user_defined_clouds from the profile local variable.
-        # The user just wants to see the cloud and version information.
-        profile.pop('user_defined_clouds')
+    # remove user_defined_clouds from the profile local variable.
+    # The user wants to see just the cloud and version information.
+    profile.pop('user_defined_clouds')
 
     return profile
 

--- a/msgraph/command_modules/profile/custom.py
+++ b/msgraph/command_modules/profile/custom.py
@@ -89,9 +89,13 @@ def select_version():
 def show_profile():
     profile = read_profile()
 
-    # remove user_defined_clouds from the profile local variable.
-    # The user just wants to see the cloud and version information.
-    profile.pop('user_defined_clouds')
+    if len(profile) == 0:
+        profile = {'cloud': DEFAULT_CLOUDS.get('PUBLIC'), 'version': 'v1.0'}
+    else:
+        # remove user_defined_clouds from the profile local variable.
+        # The user just wants to see the cloud and version information.
+        profile.pop('user_defined_clouds')
+
     return profile
 
 

--- a/msgraph/command_modules/profile/custom.py
+++ b/msgraph/command_modules/profile/custom.py
@@ -14,10 +14,6 @@ from ._cloud_manager import CloudManager
 cloud_manager = CloudManager()
 
 
-def current_cloud():
-    return cloud_manager.get_current_cloud() or DEFAULT_CLOUDS['PUBLIC']
-
-
 def delete_cloud(name: str):
     cloud_manager.delete_cloud(name)
     print(f'Cloud "{name}" deleted successfully')
@@ -90,9 +86,13 @@ def select_version():
     print(f'Version {selected_version} selected')
 
 
-def show_version():
-    version = read_profile().get('version', 'v1.0')
-    print(f'Graph Version: {version}')
+def show_profile():
+    profile = read_profile()
+
+    # remove user_defined_clouds from the profile local variable.
+    # The user just wants to see the cloud and version information.
+    profile.pop('user_defined_clouds')
+    return profile
 
 
 def _validate(url: str):


### PR DESCRIPTION
## Overview

Move commands from the **cloud** command group to the **profile** command group.
Removes show-current commands from the cloud and graph-version command groups
Adds `show-profile` command

### Demo

![image](https://user-images.githubusercontent.com/12011447/101768116-3d50bf80-3af6-11eb-8370-0dce01fba106.png)


![image](https://user-images.githubusercontent.com/12011447/103516776-20ec3c80-4e82-11eb-80cf-51fe5f61d6dc.png)


### Notes

N/A

## Testing Instructions

* Pull these changes
* Build and run the docker container -- instructions are in README.md
* Run `mg profile -h` to see the list of commands
* Run `mg profile show-profile` to see your current profile