### PR TITLE
Add MSI signing

### DIFF
--- a/.azure-pipelines/package-cli.yml
+++ b/.azure-pipelines/package-cli.yml
@@ -44,6 +44,53 @@ stages:
             cd build_scripts/windows/scripts
             build.cmd
 
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+        displayName: 'ESRP DLL CodeSigning (Microsoft.Graph.Core)'
+        inputs:
+          ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+          FolderPath: build_scripts/windows/out/
+          Pattern: *.msi
+          signConfigType: inlineSignParams
+          inlineOperation: |
+            [
+              {
+                  "keyCode": "CP-230012",
+                  "operationSetCode": "SigntoolSign",
+                  "parameters": [
+                      {
+                          "parameterName": "OpusName",
+                          "parameterValue": "Microsoft"
+                      },
+                      {
+                          "parameterName": "OpusInfo",
+                          "parameterValue": "http://www.microsoft.com"
+                      },
+                      {
+                          "parameterName": "FileDigest",
+                          "parameterValue": "/fd \"SHA256\""
+                      },
+                      {
+                          "parameterName": "PageHash",
+                          "parameterValue": "/NPH"
+                      },
+                      {
+                          "parameterName": "TimeStamp",
+                          "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                      }
+                  ],
+                  "toolName": "sign",
+                  "toolVersion": "1.0"
+              },
+              {
+                  "keyCode": "CP-230012",
+                  "operationSetCode": "SigntoolVerify",
+                  "parameters": [],
+                  "toolName": "sign",
+                  "toolVersion": "1.0"
+              }
+            ]
+          SessionTimeout: 20
+
       - task: PublishPipelineArtifact@1
         displayName: 'Publish msgraph-cli artifact'
         inputs:

--- a/.azure-pipelines/package-cli.yml
+++ b/.azure-pipelines/package-cli.yml
@@ -49,7 +49,7 @@ stages:
         inputs:
           ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
           FolderPath: build_scripts/windows/out/
-          Pattern: *.msi
+          Pattern: '*.msi'
           signConfigType: inlineSignParams
           inlineOperation: |
             [

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jobala @ddyett @MichaelMainer


### PR DESCRIPTION
## Overview

Adds task to sign the MSI. Resolves #51 

![image](https://user-images.githubusercontent.com/8527305/103608645-a8609c80-4ed0-11eb-8d31-032d164f7cff.png)

## Testing Instructions

Run the `Build MSI Package Python37` stage in the Azure pipeline.