### PR TITLE
Disable logging to file

### DIFF
--- a/msgraph/cli/core/mglogging.py
+++ b/msgraph/cli/core/mglogging.py
@@ -97,7 +97,7 @@ class MgCliLogging(CLILogging):
             # overwrite CLILogging._is_file_log_enabled() from knack
             self.file_log_enabled = cli_ctx.config.getboolean('logging',
                                                               'enable_log_file',
-                                                              fallback=True)
+                                                              fallback=False)
 
             if self.file_log_enabled:
                 self._init_command_logfile_handlers(cmd_logger, args)  # pylint: disable=protected-access


### PR DESCRIPTION
## Overview

Disable writing logs to file

### Demo

N/A

### Notes

I will need to take time and investigate why azure-cli logs to file and how they use the logs and since we are not using the logs right now I have opted to disable the logging to file functionality.

## Testing Instructions

* Delete `~/./mg/commands` directory
* Run `./mg users user list`
* Observe that the commands directory is not created

Closes #106 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-cli/pull/118)