### PR TITLE
Make passing scopes optional

### DIFF
--- a/msgraph/cli/__main__.py
+++ b/msgraph/cli/__main__.py
@@ -38,7 +38,7 @@ You're using the default profile
 CLOUD: {DEFAULT_PROFILE['cloud']}
 VERSION: {DEFAULT_PROFILE['version']}
 
-Run mg profile -h for profile commands
+Run mg cloud -h to manage your cloud profile
         '''
     print(Fore.YELLOW + msg)
 

--- a/msgraph/command_modules/authentication/custom.py
+++ b/msgraph/command_modules/authentication/custom.py
@@ -9,7 +9,7 @@ from msgraph.cli.core.authentication import Authentication
 authentication = Authentication()
 
 
-def login(scopes: str, client_id=None, tenant_id=None):
+def login(scopes='user.read', client_id=None, tenant_id=None):
     # Stripping whitespaces so that users don't have to worry about how
     # they enter scopes. ie "user.read, mail.read" or "user.read,mail.read"
     scopes = [scope.strip() for scope in scopes.split(',')]


### PR DESCRIPTION
## Overview

Allows users to login without specifying the scopes parameter by defaulting to the `user.read` scope.

### Demo

N/A

### Notes

N/A

## Testing Instructions

* Run `./mg login`
* Observe that you're logged in successfuly

Fixes #125 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-cli/pull/127)