### PR TITLE
Release

### DIFF
--- a/docs/samples/login.md
+++ b/docs/samples/login.md
@@ -5,6 +5,7 @@
  ```
 
  #### Login to your own tenant
+ In your app registration set the redirect uri as `http://localhost:8400/`
 
  ```sh
  mg login --scopes "user.read.all" --client-id YOUR_CLIENT_ID --tenant-id YOUR_TENANT_ID

--- a/msgraph/cli/__main__.py
+++ b/msgraph/cli/__main__.py
@@ -38,7 +38,7 @@ You're using the default profile
 CLOUD: {DEFAULT_PROFILE['cloud']}
 VERSION: {DEFAULT_PROFILE['version']}
 
-Run mg profile -h for profile commands
+Run mg cloud -h to manage your cloud profile
         '''
     print(Fore.YELLOW + msg)
 

--- a/msgraph/cli/core/__init__.py
+++ b/msgraph/cli/core/__init__.py
@@ -17,7 +17,7 @@ from msgraph.cli.core.constants import EXCLUDED_PARAMS
 from msgraph.cli.core.command_loaders import MainCommandsLoader, ExtensionCommandsLoader
 from msgraph.cli.core.mglogging import MgCliLogging
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 
 class MgCLI(CLI):

--- a/msgraph/command_modules/authentication/custom.py
+++ b/msgraph/command_modules/authentication/custom.py
@@ -9,7 +9,7 @@ from msgraph.cli.core.authentication import Authentication
 authentication = Authentication()
 
 
-def login(scopes: str, client_id=None, tenant_id=None):
+def login(scopes='user.read', client_id=None, tenant_id=None):
     # Stripping whitespaces so that users don't have to worry about how
     # they enter scopes. ie "user.read, mail.read" or "user.read,mail.read"
     scopes = [scope.strip() for scope in scopes.split(',')]


### PR DESCRIPTION
## Overview

* Allows user to sign in without specifying scopes by defaulting `user.read`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-cli/pull/128)