### PR TITLE
Task: Add release notification

### DIFF
--- a/.github/.workflows/release-notification.yml
+++ b/.github/.workflows/release-notification.yml
@@ -1,0 +1,20 @@
+name: Release notification
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  send_message_job:
+    runs-on: ubuntu-latest
+    name: Release notification
+    steps:
+      - name: Send a message to Microsoft Teams
+        uses: aliencube/microsoft-teams-actions@v0.8.0
+        with:
+          webhook_uri: ${{ secrets.TEAMS_WEBHOOK_URL}}
+          title: New release ${{ github.event.release.name }} from ${{ github.event.repository.name }}
+          summary: A new release (${{ github.event.release.tag_name }}) has been created
+          text: ${{ github.event.release.body }}
+          theme_color: 0000FF
+          actions: '[{"@type": "OpenUri", "name": "View release", "targets": [{ "os": "default", "uri": "${{ github.event.release.html_url }}"}]}]'


### PR DESCRIPTION
## Overview

Automates sending a teams notification once a release has been published.


### Notes

- Add an incoming webhook connector to the chosen Microsoft Teams channel 
- Place the webhook URL into the repository secrets under **TEAMS_WEBHOOK_URL**

## Testing Instructions

* Should run once a Release is published

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-cli/pull/129)