### PR TITLE
Feat/integrate auth

### DIFF
--- a/msgraph/cli/command_modules/cloud/__init__.py
+++ b/msgraph/cli/command_modules/cloud/__init__.py
@@ -23,7 +23,7 @@ class CloudCommandsLoader(AzCommandsLoader):
 
         with self.command_group('cloud', cloud_custom) as g:
             g.command('list', 'list_clouds')
-            g.command('show', 'show_cloud')
+            g.show_command('show', 'show_cloud')
             g.command('register', 'register_cloud')
             g.command('unregister', 'unregister_cloud')
             g.command('set', 'set_cloud')

--- a/msgraph/cli/command_modules/cloud/__init__.py
+++ b/msgraph/cli/command_modules/cloud/__init__.py
@@ -23,7 +23,7 @@ class CloudCommandsLoader(AzCommandsLoader):
 
         with self.command_group('cloud', cloud_custom) as g:
             g.command('list', 'list_clouds')
-            g.show_command('show', 'show_cloud')
+            g.command('show', 'show_cloud')
             g.command('register', 'register_cloud')
             g.command('unregister', 'unregister_cloud')
             g.command('set', 'set_cloud')

--- a/msgraph/cli/command_modules/profile/__init__.py
+++ b/msgraph/cli/command_modules/profile/__init__.py
@@ -16,28 +16,27 @@ cloud_resource_types = ["oss-rdbms", "arm", "aad-graph", "ms-graph", "batch", "m
 
 
 class ProfileCommandsLoader(AzCommandsLoader):
-
     def __init__(self, cli_ctx=None):
         super(ProfileCommandsLoader, self).__init__(cli_ctx=cli_ctx)
 
     def load_command_table(self, args):
 
         profile_custom = CliCommandType(
-            operations_tmpl='msgraph.cli.command_modules.profile.custom#{}'
-        )
+            operations_tmpl='msgraph.cli.command_modules.profile.custom#{}')
 
         with self.command_group('', profile_custom) as g:
             g.command('login', 'login')
             g.command('logout', 'logout')
             g.command('self-test', 'check_cli', deprecate_info=g.deprecate(hide=True))
 
-        with self.command_group('account', profile_custom) as g:
-            g.command('list', 'list_subscriptions', table_transformer=transform_account_list)
-            g.command('set', 'set_active_subscription')
-            g.show_command('show', 'show_subscription')
-            g.command('clear', 'account_clear')
-            g.command('list-locations', 'list_locations')
-            g.command('get-access-token', 'get_access_token')
+        # This functionality is meant to support Azure subscription management.
+        # with self.command_group('account', profile_custom) as g:
+        #     g.command('list', 'list_subscriptions', table_transformer=transform_account_list)
+        #     g.command('set', 'set_active_subscription')
+        #     g.show_command('show', 'show_subscription')
+        #     g.command('clear', 'account_clear')
+        #     g.command('list-locations', 'list_locations')
+        #     g.command('get-access-token', 'get_access_token')
 
         return self.command_table
 
@@ -46,37 +45,94 @@ class ProfileCommandsLoader(AzCommandsLoader):
         from azure.cli.core.api import get_subscription_id_list
 
         with self.argument_context('login') as c:
-            c.argument('password', options_list=['--password', '-p'], help="Credentials like user password, or for a service principal, provide client secret or a pem file with key and public certificate. Will prompt if not given.")
-            c.argument('service_principal', action='store_true', help='The credential representing a service principal.')
-            c.argument('username', options_list=['--username', '-u'], help='user name, service principal, or managed service identity ID')
-            c.argument('tenant', options_list=['--tenant', '-t'], help='The AAD tenant, must provide when using service principals.', validator=validate_tenant)
-            c.argument('allow_no_subscriptions', action='store_true', help="Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as 'az ad'")
+            c.argument(
+                'password',
+                options_list=['--password', '-p'],
+                help=
+                "Credentials like user password, or for a service principal, provide client secret or a pem file with key and public certificate. Will prompt if not given."
+            )
+            c.argument('service_principal',
+                       action='store_true',
+                       help='The credential representing a service principal.')
+            c.argument('username',
+                       options_list=['--username', '-u'],
+                       help='user name, service principal, or managed service identity ID')
+            c.argument('tenant',
+                       options_list=['--tenant', '-t'],
+                       help='The AAD tenant, must provide when using service principals.',
+                       validator=validate_tenant)
+            c.argument(
+                'allow_no_subscriptions',
+                action='store_true',
+                help=
+                "Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as 'az ad'"
+            )
             c.ignore('_subscription')  # hide the global subscription parameter
-            c.argument('identity', options_list=('-i', '--identity'), action='store_true', help="Log in using the Virtual Machine's identity", arg_group='Managed Service Identity')
-            c.argument('identity_port', type=int, help="the port to retrieve tokens for login. Default: 50342", arg_group='Managed Service Identity')
-            c.argument('use_device_code', action='store_true',
-                       help="Use CLI's old authentication flow based on device code. CLI will also use this if it can't launch a browser in your behalf, e.g. in remote SSH or Cloud Shell")
-            c.argument('use_cert_sn_issuer', action='store_true', help='used with a service principal configured with Subject Name and Issuer Authentication in order to support automatic certificate rolls')
+            c.argument('identity',
+                       options_list=('-i', '--identity'),
+                       action='store_true',
+                       help="Log in using the Virtual Machine's identity",
+                       arg_group='Managed Service Identity')
+            c.argument('identity_port',
+                       type=int,
+                       help="the port to retrieve tokens for login. Default: 50342",
+                       arg_group='Managed Service Identity')
+            c.argument(
+                'use_device_code',
+                action='store_true',
+                help=
+                "Use CLI's old authentication flow based on device code. CLI will also use this if it can't launch a browser in your behalf, e.g. in remote SSH or Cloud Shell"
+            )
+            c.argument(
+                'use_cert_sn_issuer',
+                action='store_true',
+                help=
+                'used with a service principal configured with Subject Name and Issuer Authentication in order to support automatic certificate rolls'
+            )
 
         with self.argument_context('logout') as c:
-            c.argument('username', help='account user, if missing, logout the current active account')
+            c.argument('username',
+                       help='account user, if missing, logout the current active account')
             c.ignore('_subscription')  # hide the global subscription parameter
 
         with self.argument_context('account') as c:
-            c.argument('subscription', options_list=['--subscription', '-s'], arg_group='', help='Name or ID of subscription.', completer=get_subscription_id_list)
+            c.argument('subscription',
+                       options_list=['--subscription', '-s'],
+                       arg_group='',
+                       help='Name or ID of subscription.',
+                       completer=get_subscription_id_list)
             c.ignore('_subscription')
 
         with self.argument_context('account list') as c:
-            c.argument('all', help="List all subscriptions, rather than just 'Enabled' ones", action='store_true')
-            c.argument('refresh', help="retrieve up-to-date subscriptions from server", action='store_true')
+            c.argument('all',
+                       help="List all subscriptions, rather than just 'Enabled' ones",
+                       action='store_true')
+            c.argument('refresh',
+                       help="retrieve up-to-date subscriptions from server",
+                       action='store_true')
             c.ignore('_subscription')  # hide the global subscription parameter
 
         with self.argument_context('account show') as c:
-            c.argument('show_auth_for_sdk', options_list=['--sdk-auth'], action='store_true', help='Output result to a file compatible with Azure SDK auth. Only applicable when authenticating with a Service Principal.')
+            c.argument(
+                'show_auth_for_sdk',
+                options_list=['--sdk-auth'],
+                action='store_true',
+                help=
+                'Output result to a file compatible with Azure SDK auth. Only applicable when authenticating with a Service Principal.'
+            )
 
         with self.argument_context('account get-access-token') as c:
-            c.argument('resource_type', get_enum_type(cloud_resource_types), options_list=['--resource-type'], arg_group='', help='Type of well-known resource.')
-            c.argument('tenant', options_list=['--tenant', '-t'], help='Tenant ID for which the token is acquired. Only available for user and service principal account, not for MSI or Cloud Shell account')
+            c.argument('resource_type',
+                       get_enum_type(cloud_resource_types),
+                       options_list=['--resource-type'],
+                       arg_group='',
+                       help='Type of well-known resource.')
+            c.argument(
+                'tenant',
+                options_list=['--tenant', '-t'],
+                help=
+                'Tenant ID for which the token is acquired. Only available for user and service principal account, not for MSI or Cloud Shell account'
+            )
 
 
 COMMAND_LOADER_CLS = ProfileCommandsLoader

--- a/msgraph/cli/command_modules/profile/_help.py
+++ b/msgraph/cli/command_modules/profile/_help.py
@@ -4,31 +4,30 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-
 from knack.help_files import helps  # pylint: disable=unused-import
 
 helps['login'] = """
 type: command
-short-summary: Log in to Azure.
+short-summary: Log in to Microsoft Graph.
 examples:
     - name: Log in interactively.
       text: >
-        az login
+        mg login
     - name: Log in with user name and password. This doesn't work with Microsoft accounts or accounts that have two-factor authentication enabled. Use -p=secret if the first character of the password is '-'.
       text: >
-        az login -u johndoe@contoso.com -p VerySecret
+        mg login -u johndoe@contoso.com -p VerySecret
     - name: Log in with a service principal using client secret. Use -p=secret if the first character of the password is '-'.
       text: >
-        az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p VerySecret --tenant contoso.onmicrosoft.com
+        mg login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p VerySecret --tenant contoso.onmicrosoft.com
     - name: Log in with a service principal using client certificate.
       text: >
-        az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
+        mg login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
     - name: Log in using a VM's system assigned identity
       text: >
-        az login --identity
+        mg login --identity
     - name: Log in using a VM's user assigned identity. Client or object ids of the service identity also work
       text: >
-        az login --identity -u /subscriptions/<subscriptionId>/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID
+        mg login --identity -u /subscriptions/<subscriptionId>/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID
 """
 
 helps['account'] = """

--- a/msgraph/cli/command_modules/profile/custom.py
+++ b/msgraph/cli/command_modules/profile/custom.py
@@ -129,7 +129,8 @@ def login(cmd,
           use_device_code=False,
           use_cert_sn_issuer=None,
           tenant_access=False,
-          environment=False):
+          environment=False,
+          scopes=None):
     """Log in to access Azure subscriptions"""
     from adal.adal_error import AdalError
     import requests
@@ -179,7 +180,8 @@ def login(cmd,
                                       use_device_code=use_device_code,
                                       allow_no_subscriptions=True,
                                       use_cert_sn_issuer=use_cert_sn_issuer,
-                                      find_subscriptions=False)
+                                      find_subscriptions=False,
+                                      scopes=scopes)
     except AdalError as err:
         # try polish unfriendly server errors
         if username:


### PR DESCRIPTION
## Overview

Integrates Azure CLI's auth module.

### Demo

```
Command
    mg login : Log in to Microsoft Graph.

Arguments
    --allow-no-subscriptions : Support access tenants without subscriptions. It's uncommon but
                               useful to run tenant level commands, such as 'az ad'.
    --environment
    --password -p            : Credentials like user password, or for a service principal, provide
                               client secret or a pem file with key and public certificate. Will
                               prompt if not given.
    --scopes
    --service-principal      : The credential representing a service principal.
    --tenant -t              : The AAD tenant, must provide when using service principals.
    --tenant-access
    --use-cert-sn-issuer     : Used with a service principal configured with Subject Name and Issuer
                               Authentication in order to support automatic certificate rolls.
    --use-device-code        : Use CLI's old authentication flow based on device code. CLI will also
                               use this if it can't launch a browser in your behalf, e.g. in remote
                               SSH or Cloud Shell.
    --username -u            : User name, service principal, or managed service identity ID.

Managed Service Identity Arguments
    --identity -i            : Log in using the Virtual Machine's identity.
```

### Notes
N/A

## Testing Instructions

* Run `./mg login --scopes mail.read` to login in and consent to the specified scopes
* Run `./mg login` to login with defaut scopes

Fixes #133 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-cli/pull/146)