### PR TITLE
Feat/integrate config

### DIFF
--- a/msgraph/cli/command_modules/config/__init__.py
+++ b/msgraph/cli/command_modules/config/__init__.py
@@ -1,0 +1,25 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.core import AzCommandsLoader
+
+import msgraph.cli.command_modules.config._help  # pylint: disable=unused-import
+
+
+class ConfigCommandsLoader(AzCommandsLoader):
+    def __init__(self, cli_ctx=None):
+        super(ConfigCommandsLoader, self).__init__(cli_ctx=cli_ctx)
+
+    def load_command_table(self, args):
+        from msgraph.cli.command_modules.config.commands import load_command_table
+        load_command_table(self, args)
+        return self.command_table
+
+    def load_arguments(self, command):
+        from msgraph.cli.command_modules.config._params import load_arguments
+        load_arguments(self, command)
+
+
+COMMAND_LOADER_CLS = ConfigCommandsLoader

--- a/msgraph/cli/command_modules/config/_help.py
+++ b/msgraph/cli/command_modules/config/_help.py
@@ -1,0 +1,90 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from knack.help_files import helps  # pylint: disable=unused-import
+# pylint: disable=line-too-long, too-many-lines
+
+helps['config'] = """
+type: group
+short-summary: Manage Microsoft Graph CLI configuration.
+"""
+
+helps['config set'] = """
+type: command
+short-summary: Set a configuration.
+long-summary: |
+    For available configuration options, see https://docs.microsoft.com/cli/azure/azure-cli-configuration.
+    By default without specifying --local, the configuration will be saved to `~/.azure/config`.
+examples:
+  - name: Disable color with `core.no_color`.
+    text: mg config set core.no_color=true
+  - name: Hide warnings and only show errors with `core.only_show_errors`.
+    text: mg config set core.only_show_errors=true
+  - name: Turn on client-side telemetry.
+    text: mg config set core.collect_telemetry=true
+  - name: Turn on file logging and set its location.
+    text: |-
+        mg config set logging.enable_log_file=true
+        mg config set logging.log_dir=~/az-logs
+  """
+
+helps['config get'] = """
+type: command
+short-summary: Get a configuration.
+examples:
+  - name: Get all configurations.
+    text: mg config get
+  - name: Get configurations in `core` section.
+    text: mg config get core
+  - name: Get the configuration of key `core.no_color`.
+    text: mg config get core.no_color
+"""
+
+helps['config unset'] = """
+type: command
+short-summary: Unset a configuration.
+examples:
+  - name: Unset the configuration of key `core.no_color`.
+    text: az config unset core.no_color
+"""
+
+helps['config param-persist'] = """
+type: group
+short-summary: Manage parameter persistence.
+"""
+
+helps['config param-persist on'] = """
+type: command
+short-summary: Turn on parameter persistence.
+"""
+
+helps['config param-persist off'] = """
+type: command
+short-summary: Turn off parameter persistence.
+"""
+
+helps['config param-persist show'] = """
+type: command
+short-summary: Show parameter persistence data.
+examples:
+  - name: Show all parameter persistence value
+    text: az config param-persist show
+  - name: Show resource_group_name parameter persistence value
+    text: az config param-persist show resource_group_name
+"""
+
+helps['config param-persist delete'] = """
+type: command
+short-summary: Delete parameter persistence data.
+examples:
+  - name: Delete resource_group_name from parameter persistence
+    text: az config param-persist delete resource_group_name
+  - name: Clear all parameter persistence data
+    text: az config param-persist delete --all
+  - name: Delete parameter persistence file
+    text: az config param-persist delete --all --purge
+  - name: Delete parameter persistence file recursively
+    text: az config param-persist delete --all --purge --recursive
+"""

--- a/msgraph/cli/command_modules/config/_help.py
+++ b/msgraph/cli/command_modules/config/_help.py
@@ -47,7 +47,7 @@ type: command
 short-summary: Unset a configuration.
 examples:
   - name: Unset the configuration of key `core.no_color`.
-    text: az config unset core.no_color
+    text: mg config unset core.no_color
 """
 
 helps['config param-persist'] = """
@@ -80,11 +80,11 @@ type: command
 short-summary: Delete parameter persistence data.
 examples:
   - name: Delete resource_group_name from parameter persistence
-    text: az config param-persist delete resource_group_name
+    text: mg config param-persist delete resource_group_name
   - name: Clear all parameter persistence data
-    text: az config param-persist delete --all
+    text: mg config param-persist delete --all
   - name: Delete parameter persistence file
-    text: az config param-persist delete --all --purge
+    text: mg config param-persist delete --all --purge
   - name: Delete parameter persistence file recursively
-    text: az config param-persist delete --all --purge --recursive
+    text: mg config param-persist delete --all --purge --recursive
 """

--- a/msgraph/cli/command_modules/config/_params.py
+++ b/msgraph/cli/command_modules/config/_params.py
@@ -1,0 +1,40 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+# pylint: disable=line-too-long
+
+
+def load_arguments(self, _):
+    with self.argument_context('config') as c:
+        c.ignore('_subscription')  # ignore the global subscription param
+
+    with self.argument_context('config set') as c:
+        c.positional('key_value', nargs='+', help="Space-separated configurations in the form of <section>.<key>=<value>.")
+        c.argument('local', action='store_true', help='Set as a local configuration in the working directory.')
+
+    with self.argument_context('config get') as c:
+        c.positional('key', nargs='?', help='The configuration to get. '
+                                            'If not provided, all sections and configurations will be listed. '
+                                            'If `section` is provided, all configurations under the specified section will be listed. '
+                                            'If `<section>.<key>` is provided, only the corresponding configuration is shown.')
+        c.argument('local', action='store_true',
+                   help='Include local configuration. Scan from the working directory up to the root drive, then the global configuration '
+                        'and return the first occurrence.')
+
+    with self.argument_context('config unset') as c:
+        c.positional('key', nargs='+', help='The configuration to unset, in the form of <section>.<key>.')
+        c.argument('local', action='store_true',
+                   help='Include local configuration. Scan from the working directory up to the root drive, then the global configuration '
+                        'and unset the first occurrence.')
+
+    with self.argument_context('config param-persist show') as c:
+        c.positional('name', nargs='*', help='Space-separated list of parameter persistence names.')
+
+    with self.argument_context('config param-persist delete') as c:
+        c.positional('name', nargs='*', help='Space-separated list of parameter persistence names. Either positional name argument or --all can be specified.')
+        c.argument('all', help='Clear all parameter persistence data. Either positional name argument  or --all can be specified.', action='store_true')
+        c.argument('yes', options_list=['--yes', '-y'], help='Do not prompt for confirmation. Only available when --all is specified.', action='store_true')
+        c.argument('purge', help='Delete parameter persistence file from working directory. Only available when --all is specified.', action='store_true')
+        c.argument('recursive', help='Indicate this is recursive delete of parameter persistence. Only available when --all is specified.', action='store_true')

--- a/msgraph/cli/command_modules/config/_validators.py
+++ b/msgraph/cli/command_modules/config/_validators.py
@@ -1,0 +1,21 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from knack.util import CLIError
+
+
+def validate_param_persist(cmd, namespace):  # pylint: disable=unused-argument
+    if not cmd.cli_ctx.local_context.username:
+        raise CLIError('Can\'t get system user account. Parameter persist is ignored.')
+    if not cmd.cli_ctx.local_context.current_dir:
+        raise CLIError('The working directory has been deleted or recreated. You can change to another working '
+                       'directory or reenter current one if it is recreated.')
+
+
+def validate_param_persist_for_delete(cmd, namespace):
+    if (namespace.all and namespace.name) or (not namespace.all and not namespace.name):
+        raise CLIError('Please specify either positional argument name or --all.')
+
+    validate_param_persist(cmd, namespace)

--- a/msgraph/cli/command_modules/config/commands.py
+++ b/msgraph/cli/command_modules/config/commands.py
@@ -1,0 +1,22 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.core.commands import CliCommandType
+from msgraph.cli.command_modules.config._validators import validate_param_persist, validate_param_persist_for_delete
+
+
+def load_command_table(self, _):
+    config_custom = CliCommandType(operations_tmpl='msgraph.cli.command_modules.config.custom#{}')
+
+    with self.command_group('config', config_custom, is_experimental=True) as g:
+        g.command('set', 'config_set')
+        g.command('get', 'config_get')
+        g.command('unset', 'config_unset')
+
+    with self.command_group('config param-persist', config_custom, is_experimental=True) as g:
+        g.command('on', 'turn_param_persist_on')
+        g.command('off', 'turn_param_persist_off')
+        g.show_command('show', 'show_param_persist', validator=validate_param_persist)
+        g.command('delete', 'delete_param_persist', validator=validate_param_persist_for_delete)

--- a/msgraph/cli/command_modules/config/custom.py
+++ b/msgraph/cli/command_modules/config/custom.py
@@ -1,0 +1,132 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from knack.log import get_logger
+from knack.util import CLIError
+
+from azure.cli.core.util import ScopedConfig
+
+import azure.cli.core.telemetry as telemetry
+
+logger = get_logger(__name__)
+
+
+def _normalize_config_value(value):
+    if value:
+        value = '' if value in ["''", '""'] else value
+    return value
+
+
+def config_set(cmd, key_value=None, local=False):
+    if key_value:
+        with ScopedConfig(cmd.cli_ctx.config, local):
+            telemetry_contents = []
+            for kv in key_value:
+                # core.no_color=true
+                parts = kv.split('=', 1)
+                if len(parts) == 1:
+                    raise CLIError('usage error: [section].[name]=[value] ...')
+                key = parts[0]
+                value = parts[1]
+
+                # core.no_color
+                parts = key.split('.', 1)
+                if len(parts) == 1:
+                    raise CLIError('usage error: [section].[name]=[value] ...')
+                section = parts[0]
+                name = parts[1]
+
+                cmd.cli_ctx.config.set_value(section, name, _normalize_config_value(value))
+                telemetry_contents.append((key, section, value))
+            telemetry.set_debug_info('ConfigSet', telemetry_contents)
+
+
+def config_get(cmd, key=None, local=False):
+    # No arg. List all sections and all items
+    if not key:
+        with ScopedConfig(cmd.cli_ctx.config, local):
+            sections = cmd.cli_ctx.config.sections()
+            result = {}
+            for section in sections:
+                items = cmd.cli_ctx.config.items(section)
+                result[section] = items
+            return result
+
+    parts = key.split('.', 1)
+    if len(parts) == 1:
+        # Only section is provided
+        section = key
+        name = None
+    else:
+        # section.name
+        section = parts[0]
+        name = parts[1]
+
+    with ScopedConfig(cmd.cli_ctx.config, local):
+        items = cmd.cli_ctx.config.items(section)
+
+    if not name:
+        # Only section
+        return items
+
+    # section.option
+    try:
+        return next(x for x in items if x['name'] == name)
+    except StopIteration:
+        raise CLIError("Configuration '{}' is not set.".format(key))
+
+
+def config_unset(cmd, key=None, local=False):
+    for k in key:
+        # section.name
+        parts = k.split('.', 1)
+
+        if len(parts) == 1:
+            raise CLIError("usage error: [section].[name]")
+
+        section = parts[0]
+        name = parts[1]
+
+        with ScopedConfig(cmd.cli_ctx.config, local):
+            cmd.cli_ctx.config.remove_option(section, name)
+    telemetry.set_debug_info('ConfigUnset', ' '.join(key))
+
+
+def turn_param_persist_on(cmd):
+    if not cmd.cli_ctx.local_context.is_on:
+        cmd.cli_ctx.local_context.turn_on()
+        logger.warning('Parameter persistence is turned on, you can run `az config param-persist off` to turn it off.')
+    else:
+        logger.warning('Parameter persistence is on already.')
+
+
+def turn_param_persist_off(cmd):
+    if cmd.cli_ctx.local_context.is_on:
+        cmd.cli_ctx.local_context.turn_off()
+        logger.warning('Parameter persistence is turned off, you can run `az config param-persist on` to turn it on.')
+    else:
+        logger.warning('Parameter persistence is off already.')
+
+
+def show_param_persist(cmd, name=None):
+    if not name:
+        name = None
+    return cmd.cli_ctx.local_context.get_value(name)
+
+
+def delete_param_persist(cmd, name=None, all=False, yes=False, purge=False, recursive=False):  # pylint: disable=redefined-builtin
+    if name:
+        cmd.cli_ctx.local_context.delete(name)
+
+    if all:
+        from azure.cli.core.util import user_confirmation
+        if purge:
+            user_confirmation('You are going to delete parameter persistence file. '
+                              'Are you sure you want to continue this operation ?', yes)
+            cmd.cli_ctx.local_context.delete_file(recursive)
+        else:
+            user_confirmation('You are going to clear all parameter persistence values. '
+                              'Are you sure you want to continue this operation ?', yes)
+            cmd.cli_ctx.local_context.clear(recursive)

--- a/msgraph/cli/command_modules/config/tests/__init__.py
+++ b/msgraph/cli/command_modules/config/tests/__init__.py
@@ -1,0 +1,4 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------

--- a/msgraph/cli/command_modules/config/tests/latest/__init__.py
+++ b/msgraph/cli/command_modules/config/tests/latest/__init__.py
@@ -1,0 +1,4 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------

--- a/msgraph/cli/command_modules/config/tests/latest/test_config.py
+++ b/msgraph/cli/command_modules/config/tests/latest/test_config.py
@@ -1,0 +1,81 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+from azure.cli.testsdk import ScenarioTest, LocalContextScenarioTest
+from knack.util import CLIError
+
+
+class ConfigTest(ScenarioTest):
+
+    def test_config(self):
+
+        # [test_section1]
+        # test_option1 = test_value1
+        #
+        # [test_section2]
+        # test_option21 = test_value21
+        # test_option22 = test_value22
+
+        # C:\Users\{username}\AppData\Local\Temp
+        tempdir = os.path.realpath(tempfile.gettempdir())  # call realpath to handle soft link problem on MAC
+        original_path = os.getcwd()
+        os.chdir(tempdir)
+        print("Using temp dir: {}".format(tempdir))
+
+        global_test_args = {"source": os.path.expanduser(os.path.join('~', '.azure', 'config')), "flag": ""}
+        local_test_args = {"source": os.path.join(tempdir, '.azure', 'config'), "flag": " --local"}
+
+        for args in (global_test_args, local_test_args):
+            test_option1_expected = {'name': 'test_option1', 'source': args["source"], 'value': 'test_value1'}
+            test_option21_expected = {'name': 'test_option21', 'source': args["source"], 'value': 'test_value21'}
+            test_option22_expected = {'name': 'test_option22', 'source': args["source"], 'value': 'test_value22'}
+
+            test_section1_expected = [test_option1_expected]
+            test_section2_expected = [test_option21_expected, test_option22_expected]
+
+            # 1. set
+            # Test setting one option
+            self.cmd('config set test_section1.test_option1=test_value1' + args['flag'])
+            # Test setting multiple options
+            self.cmd('config set test_section2.test_option21=test_value21 test_section2.test_option22=test_value22' + args['flag'])
+
+            # 2. get
+            # 2.1 Test get all sections
+            output = self.cmd('config get' + args['flag']).get_output_in_json()
+            self.assertListEqual(output['test_section1'], test_section1_expected)
+            self.assertListEqual(output['test_section2'], test_section2_expected)
+
+            # 2.2 Test get one section
+            output = self.cmd('config get test_section1' + args['flag']).get_output_in_json()
+            self.assertListEqual(output, test_section1_expected)
+            output = self.cmd('config get test_section2' + args['flag']).get_output_in_json()
+            self.assertListEqual(output, test_section2_expected)
+
+            # 2.3 Test get one item
+            output = self.cmd('config get test_section1.test_option1' + args['flag']).get_output_in_json()
+            self.assertDictEqual(output, test_option1_expected)
+            output = self.cmd('config get test_section2.test_option21' + args['flag']).get_output_in_json()
+            self.assertDictEqual(output, test_option21_expected)
+            output = self.cmd('config get test_section2.test_option22' + args['flag']).get_output_in_json()
+            self.assertDictEqual(output, test_option22_expected)
+
+            with self.assertRaises(CLIError):
+                self.cmd('config get test_section1.test_option22' + args['flag'])
+
+            # 3. unset
+            # Test unsetting one option
+            self.cmd('config unset test_section1.test_option1' + args['flag'])
+            # Test unsetting multiple options
+            self.cmd('config unset test_section2.test_option21 test_section2.test_option22' + args['flag'])
+
+        os.chdir(original_path)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/msgraph/cli/command_modules/config/tests/latest/test_param_persist.py
+++ b/msgraph/cli/command_modules/config/tests/latest/test_param_persist.py
@@ -1,0 +1,26 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+import unittest
+
+from azure.cli.testsdk import LocalContextScenarioTest
+
+
+class ParamPersistScenarioTest(LocalContextScenarioTest):
+
+    def test_param_persist_commands(self):
+        self.cmd('config param-persist show')
+        self.cmd('config param-persist show resource_group_name vnet_name')
+        self.cmd('config param-persist delete resource_group_name vnet_name')
+        self.cmd('config param-persist delete --all -y')
+        self.cmd('config param-persist delete --all --purge -y')
+        self.cmd('config param-persist delete --all --purge -y --recursive')
+
+        from knack.util import CLIError
+        with self.assertRaises(CLIError):
+            self.cmd('config param-persist delete resource_group_name --all')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Overview

Integrates config command module from Azure CLI

### Demo

```
Group
    mg config : Manage Microsoft Graph CLI configuration.
        WARNING: This command group is experimental and under development. Reference and support
        levels: https://aka.ms/CLI_refstatus
Subgroups:
    param-persist : Manage parameter persistence.

Commands:
    get           : Get a configuration.
    set           : Set a configuration.
    unset         : Unset a configuration.
```

### Notes
The config command module provides functionality for users to control the CLI's output color, telemetry collection, and logging to file.

```
Disable color with `core.no_color`.
    mg config set core.no_color=true

Hide warnings and only show errors with `core.only_show_errors`.
    mg config set core.only_show_errors=true

Turn on client-side telemetry.
    mg config set core.collect_telemetry=true

Turn on file logging and set its location.
    mg config set logging.enable_log_file=true
    mg config set logging.log_dir=~/az-logs
```
## Testing Instructions

* Run `./mg config -h` to see the set of available commands

Fixes #140 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-cli/pull/147)