### PR TITLE
Add missing 'i' to name of libffi6

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Download directly from the [releases](https://github.com/microsoftgraph/msgraph-
 If you're using **Ubuntu 20.04+**, download and install **[libffi6](http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb)**
 
 ```bash
-sudo apt install path/to/libff6
+sudo apt install path/to/libffi6
 ```
 
 Download the .deb package from the latest [release](https://github.com/microsoftgraph/msgraph-cli/releases) and install the package with the command below.


### PR DESCRIPTION
Incorrectly listed as "libff6" instead of "libffi6"

## Overview

Fix name of libffi6 in instructions

### Demo

### Notes

## Testing Instructions

No testing necessary, only documentation change.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-cli/pull/166)