### PR TITLE
fix bug with profile storage location

### DIFF
--- a/msgraph/cli/core/constants.py
+++ b/msgraph/cli/core/constants.py
@@ -6,8 +6,8 @@
 from pathlib import Path
 from os import path
 
-AUTH_RECORD_LOCATION = path.join(Path.home(), '.mg', 'record.txt')
-PROFILE_LOCATION = path.join(Path.home(), '.mg', 'profile.json')
+AUTH_RECORD_LOCATION = path.join(Path.home(), '.mgc', 'record.txt')
+PROFILE_LOCATION = path.join(Path.home(), '.mgc', 'profile.json')
 DEFAULT_CLIENT_ID = '888bce95-fde5-40f8-a7d4-2debf0f96f4c'
 DEFAULT_AUTHORITY = 'https://login.microsoftonline.com'
 DEFAULT_BASE_URL = 'https://graph.microsoft.com/v1.0'


### PR DESCRIPTION
## Overview

FileNotFoundError on first run #172

### Demo
![image](https://user-images.githubusercontent.com/747955/129631859-ec14db48-c984-4d5d-827a-069aa0b8d82b.png)

### Notes
There's a limit of 260 characters on the path size in .NET that sometimes causes an error that looks something like:
```
heat.exe : error HEAT5059: The file '[Long file path]' cannot be found.
```
If that happens, move the project so it has a shorter root path (closer to the root of the drive).

## Testing Instructions

- Build the MSI by running `build_scripts\windows\scripts\build.cmd`
- Install the package from the MSI
- Run `mgc login --scopes "user.read.all"` in a terminal
- Once done with the browser flow, you should see the message `Logged in successfully`


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-cli/pull/179)