### PR TITLE
deprecates some auth arguments

### DIFF
--- a/msgraph/cli/command_modules/profile/__init__.py
+++ b/msgraph/cli/command_modules/profile/__init__.py
@@ -94,6 +94,8 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.ignore('allow_no_subscriptions')
             c.ignore('environment')
             c.ignore('tenant_access')
+            c.ignore('service_principal')
+            c.ignore('use_cert_sn_issuer')
 
         with self.argument_context('logout') as c:
             c.argument('username',

--- a/msgraph/cli/command_modules/profile/__init__.py
+++ b/msgraph/cli/command_modules/profile/__init__.py
@@ -12,7 +12,8 @@ import msgraph.cli.command_modules.profile._help  # pylint: disable=unused-impor
 
 from ._validators import validate_tenant
 
-cloud_resource_types = ["oss-rdbms", "arm", "aad-graph", "ms-graph", "batch", "media", "data-lake"]
+cloud_resource_types = ["oss-rdbms", "arm", "aad-graph",
+                        "ms-graph", "batch", "media", "data-lake"]
 
 
 class ProfileCommandsLoader(AzCommandsLoader):
@@ -27,7 +28,8 @@ class ProfileCommandsLoader(AzCommandsLoader):
         with self.command_group('', profile_custom) as g:
             g.command('login', 'login')
             g.command('logout', 'logout')
-            g.command('self-test', 'check_cli', deprecate_info=g.deprecate(hide=True))
+            g.command('self-test', 'check_cli',
+                      deprecate_info=g.deprecate(hide=True))
 
         # This functionality is meant to support Azure subscription management.
         # with self.command_group('account', profile_custom) as g:
@@ -48,8 +50,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument(
                 'password',
                 options_list=['--password', '-p'],
-                help=
-                "Credentials like user password, or for a service principal, provide client secret or a pem file with key and public certificate. Will prompt if not given."
+                help="Credentials like user password, or for a service principal, provide client secret or a pem file with key and public certificate. Will prompt if not given."
             )
             c.argument('service_principal',
                        action='store_true',
@@ -64,8 +65,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument(
                 'allow_no_subscriptions',
                 action='store_true',
-                help=
-                "Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as 'az ad'"
+                help="Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as 'az ad'"
             )
             c.ignore('_subscription')  # hide the global subscription parameter
             c.argument('identity',
@@ -80,15 +80,20 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument(
                 'use_device_code',
                 action='store_true',
-                help=
-                "Use CLI's old authentication flow based on device code. CLI will also use this if it can't launch a browser in your behalf, e.g. in remote SSH or Cloud Shell"
+                help="Use CLI's old authentication flow based on device code. CLI will also use this if it can't launch a browser in your behalf, e.g. in remote SSH or Cloud Shell"
             )
             c.argument(
                 'use_cert_sn_issuer',
                 action='store_true',
-                help=
-                'used with a service principal configured with Subject Name and Issuer Authentication in order to support automatic certificate rolls'
+                help='used with a service principal configured with Subject Name and Issuer Authentication in order to support automatic certificate rolls'
             )
+
+            # Hide the following arguments from the user
+            c.ignore('username')
+            c.ignore('password')
+            c.ignore('allow_no_subscriptions')
+            c.ignore('environment')
+            c.ignore('tenant_access')
 
         with self.argument_context('logout') as c:
             c.argument('username',
@@ -117,8 +122,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
                 'show_auth_for_sdk',
                 options_list=['--sdk-auth'],
                 action='store_true',
-                help=
-                'Output result to a file compatible with Azure SDK auth. Only applicable when authenticating with a Service Principal.'
+                help='Output result to a file compatible with Azure SDK auth. Only applicable when authenticating with a Service Principal.'
             )
 
         with self.argument_context('account get-access-token') as c:
@@ -130,8 +134,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument(
                 'tenant',
                 options_list=['--tenant', '-t'],
-                help=
-                'Tenant ID for which the token is acquired. Only available for user and service principal account, not for MSI or Cloud Shell account'
+                help='Tenant ID for which the token is acquired. Only available for user and service principal account, not for MSI or Cloud Shell account'
             )
 
 

--- a/msgraph/cli/command_modules/profile/_help.py
+++ b/msgraph/cli/command_modules/profile/_help.py
@@ -13,12 +13,6 @@ examples:
     - name: Log in interactively.
       text: >
         mgc login
-    - name: Log in with a service principal using client secret. Use -p=secret if the first character of the password is '-'.
-      text: >
-        mgc login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p VerySecret --tenant contoso.onmicrosoft.com
-    - name: Log in with a service principal using client certificate.
-      text: >
-        mgc login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
     - name: Log in using a VM's system assigned identity
       text: >
         mgc login --identity

--- a/msgraph/cli/command_modules/profile/_help.py
+++ b/msgraph/cli/command_modules/profile/_help.py
@@ -12,22 +12,19 @@ short-summary: Log in to Microsoft Graph.
 examples:
     - name: Log in interactively.
       text: >
-        mg login
-    - name: Log in with user name and password. This doesn't work with Microsoft accounts or accounts that have two-factor authentication enabled. Use -p=secret if the first character of the password is '-'.
-      text: >
-        mg login -u johndoe@contoso.com -p VerySecret
+        mgc login
     - name: Log in with a service principal using client secret. Use -p=secret if the first character of the password is '-'.
       text: >
-        mg login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p VerySecret --tenant contoso.onmicrosoft.com
+        mgc login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p VerySecret --tenant contoso.onmicrosoft.com
     - name: Log in with a service principal using client certificate.
       text: >
-        mg login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
+        mgc login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
     - name: Log in using a VM's system assigned identity
       text: >
-        mg login --identity
+        mgc login --identity
     - name: Log in using a VM's user assigned identity. Client or object ids of the service identity also work
       text: >
-        mg login --identity -u /subscriptions/<subscriptionId>/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID
+        mgc login --identity -u /subscriptions/<subscriptionId>/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID
 """
 
 helps['account'] = """


### PR DESCRIPTION
## Overview

Deprecates the following auth scenarios

1. authenticating with username and password
2. using service principal

Hides the following arguments from the user
1. allow no subscriptions
2. environment
3. tenant access

### Demo

<img width="1481" alt="Screen Shot 2021-09-17 at 2 24 06 PM" src="https://user-images.githubusercontent.com/12011447/133774796-ed893c4d-82a9-46df-855a-e7efa847e5ab.png">

### Notes

N/A

## Testing Instructions

* Run `mgc login -h`
* Observe that you can't sign in with username and password
* Observe that you can't sign in with a service principal

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-cli/pull/192)