### PR TITLE
Feat/update commands structure

### DIFF
--- a/build_scripts/generate_extensions.py
+++ b/build_scripts/generate_extensions.py
@@ -121,6 +121,10 @@ directive:
       set:
           group: {file_name}
     - where:
+          group: {file_name}-{parsed_file_name}
+      set:
+          group: {parsed_file_name}      
+    - where:
           group: {parsed_file_name}-{parsed_file_name}
       set:
           group: {parsed_file_name}
@@ -128,6 +132,10 @@ directive:
           command: {file_name} {parsed_file_name} create-{parsed_file_name}
       set:
           command: {file_name} {parsed_file_name} create
+    - where:
+          command: {file_name} {parsed_file_name} update-{parsed_file_name}
+      set:
+          command: {file_name} {parsed_file_name} update
     - where:
           command: {file_name} {parsed_file_name} get-{parsed_file_name}
       set:
@@ -137,9 +145,21 @@ directive:
       set:
           command: {file_name} {parsed_file_name} list
     - where:
+          command: {file_name} {parsed_file_name} show-{parsed_file_name}
+      set:
+          command: {file_name} {parsed_file_name} show
+    - where:
           command: {file_name} {parsed_file_name} update-{parsed_file_name}
       set:
           command: {file_name} {parsed_file_name} update
+    - where:
+          command: {file_name} {parsed_file_name} set-{parsed_file_name}
+      set:
+          command: {file_name} {parsed_file_name} set
+    - where:
+          command: {file_name} {parsed_file_name} delete-{parsed_file_name}
+      set:
+          command: {file_name} {parsed_file_name} delete
 
 modelerfour:
     lenient-model-deduplication: true

--- a/build_scripts/generate_extensions.py
+++ b/build_scripts/generate_extensions.py
@@ -119,11 +119,7 @@ directive:
     - where:
           group: {file_name}_{version}
       set:
-          group: {file_name}
-    - where:
-          group: {file_name}-{parsed_file_name}
-      set:
-          group: {parsed_file_name}      
+          group: {file_name}   
     - where:
           group: {parsed_file_name}-{parsed_file_name}
       set:
@@ -132,10 +128,6 @@ directive:
           command: {file_name} {parsed_file_name} create-{parsed_file_name}
       set:
           command: {file_name} {parsed_file_name} create
-    - where:
-          command: {file_name} {parsed_file_name} update-{parsed_file_name}
-      set:
-          command: {file_name} {parsed_file_name} update
     - where:
           command: {file_name} {parsed_file_name} get-{parsed_file_name}
       set:

--- a/build_scripts/generate_extensions.py
+++ b/build_scripts/generate_extensions.py
@@ -159,35 +159,35 @@ directive:
     - where:
           command: (.*)(create-)(.*)
       set:
-          command: $1 $3 create
+          command: $1$3 create
     - where:
           command: (.*)(get-)(.*)
       set:
-          command: $1 $3 get
+          command: $1$3 get
     - where:
           command: (.*)(list-)(.*)
       set:
-          command: $1 $3 list
+          command: $1$3 list
     - where:
           command: (.*)(update-)(.*)
       set:
-          command: $1 $3 update
+          command: $1$3 update
     - where:
           command: (.*)(add-)(.*)
       set:
-          command: $1 $3 add
+          command: $1$3 add
     - where:
           command: (.*)(set-)(.*)
       set:
-          command: $1 $3 set
+          command: $1$3 set
     - where:
           command: (.*)(show-)(.*)
       set:
-          command: $1 $3 show
+          command: $1$3 show
     - where:
           command: (.*)(delete-)(.*)
       set:
-          command: $1 $3 delete
+          command: $1$3 delete
 
 
 modelerfour:

--- a/build_scripts/generate_extensions.py
+++ b/build_scripts/generate_extensions.py
@@ -157,37 +157,9 @@ directive:
       set:
           command: {file_name} {parsed_file_name} delete
     - where:
-          command: (.*)(create-)(.*)
+          command: (.*)(?:(create|get|list|update|add|set|show|delete)-)(.*)
       set:
-          command: $1$3 create
-    - where:
-          command: (.*)(get-)(.*)
-      set:
-          command: $1$3 get
-    - where:
-          command: (.*)(list-)(.*)
-      set:
-          command: $1$3 list
-    - where:
-          command: (.*)(update-)(.*)
-      set:
-          command: $1$3 update
-    - where:
-          command: (.*)(add-)(.*)
-      set:
-          command: $1$3 add
-    - where:
-          command: (.*)(set-)(.*)
-      set:
-          command: $1$3 set
-    - where:
-          command: (.*)(show-)(.*)
-      set:
-          command: $1$3 show
-    - where:
-          command: (.*)(delete-)(.*)
-      set:
-          command: $1$3 delete
+          command: $1 $3 $2
 
 
 modelerfour:

--- a/build_scripts/generate_extensions.py
+++ b/build_scripts/generate_extensions.py
@@ -119,7 +119,7 @@ directive:
     - where:
           group: {file_name}_{version}
       set:
-          group: {file_name}   
+          group: {file_name}
     - where:
           group: {parsed_file_name}-{parsed_file_name}
       set:

--- a/build_scripts/generate_extensions.py
+++ b/build_scripts/generate_extensions.py
@@ -137,21 +137,58 @@ directive:
       set:
           command: {file_name} {parsed_file_name} list
     - where:
-          command: {file_name} {parsed_file_name} show-{parsed_file_name}
-      set:
-          command: {file_name} {parsed_file_name} show
-    - where:
           command: {file_name} {parsed_file_name} update-{parsed_file_name}
       set:
           command: {file_name} {parsed_file_name} update
+    - where:
+          command: {file_name} {parsed_file_name} add-{parsed_file_name}
+      set:
+          command: {file_name} {parsed_file_name} add
     - where:
           command: {file_name} {parsed_file_name} set-{parsed_file_name}
       set:
           command: {file_name} {parsed_file_name} set
     - where:
+          command: {file_name} {parsed_file_name} show-{parsed_file_name}
+      set:
+          command: {file_name} {parsed_file_name} show
+    - where:
           command: {file_name} {parsed_file_name} delete-{parsed_file_name}
       set:
           command: {file_name} {parsed_file_name} delete
+    - where:
+          command: (.*)(create-)(.*)
+      set:
+          command: $1 $3 create
+    - where:
+          command: (.*)(get-)(.*)
+      set:
+          command: $1 $3 get
+    - where:
+          command: (.*)(list-)(.*)
+      set:
+          command: $1 $3 list
+    - where:
+          command: (.*)(update-)(.*)
+      set:
+          command: $1 $3 update
+    - where:
+          command: (.*)(add-)(.*)
+      set:
+          command: $1 $3 add
+    - where:
+          command: (.*)(set-)(.*)
+      set:
+          command: $1 $3 set
+    - where:
+          command: (.*)(show-)(.*)
+      set:
+          command: $1 $3 show
+    - where:
+          command: (.*)(delete-)(.*)
+      set:
+          command: $1 $3 delete
+
 
 modelerfour:
     lenient-model-deduplication: true

--- a/build_scripts/generate_extensions.py
+++ b/build_scripts/generate_extensions.py
@@ -2,15 +2,17 @@ import os
 import sys
 from os import path
 import subprocess
+from yaml import FullLoader, load, dump
 
 
-def generate_extension_from_open_api_description(version='v1_0'):
+def generate_extension_from_open_api_description(version):
     open_api_descriptions = get_open_api_descriptions(version)
 
     for item in open_api_descriptions:
         file_name, file_path = item
         file_name = remove_file_extension_and_group(file_name)
 
+        update_operationId(file_path)
         # Config files are used to modify generated extensions
         generate_az_config_for(file_name, version)
         generate_cli_config_for(file_name, version)
@@ -23,7 +25,6 @@ def generate_extension_from_open_api_description(version='v1_0'):
             '--az',
             f'''--input-file={file_path}''',
             f'''--azure-cli-extension-folder=../msgraph-cli-extensions/{version}''',
-            r'''--use=https://github.com/Azure/autorest.az/releases/download/1.7.3-b.20210721.1/autorest-az-1.7.3.tgz''',
         ]
 
         subprocess.run(args, shell=True)
@@ -40,6 +41,31 @@ def get_open_api_descriptions(version: str):
         result.append(file_and_path)
 
     return result
+
+
+def update_operationId(file: str):
+    data = None
+
+    with open(file, 'r') as f:
+        data = load(f.read(), Loader=FullLoader)
+        for path in data['paths']:
+            verbs = data['paths'][path].keys()
+
+            for verb in verbs:
+                op_id = data['paths'][path][verb]['operationId']
+                command_group, action = op_id.split('_')
+
+                if '.' in command_group:
+
+                    # singularize
+                    entity_set, entity_type = command_group.split('.')[:2]
+                    if entity_set == (entity_type + 's'):
+                        command_group = entity_type
+
+                data['paths'][path][verb]['operationId'] = '{}_{}'.format(command_group, action)
+
+    with open(file, 'w+') as f:
+        f.write(dump(data))
 
 
 def remove_file_extension_and_group(file_name):
@@ -76,7 +102,7 @@ cli:
 
 def generate_az_config_for(file_name, version):
     parsed_file_name = file_name
-    
+
     extension_mode = 'stable'
     if version == 'beta':
         extension_mode = 'experimental'
@@ -87,6 +113,7 @@ def generate_az_config_for(file_name, version):
     if file_name[-1] == 's':
         parsed_file_name = file_name[:-1]
 
+    name = file_name if version == 'v1_0' else '{}_{}'.format(file_name, version)
     config = f"""
 # CLI
 
@@ -94,7 +121,7 @@ These settings apply only when `--az` is specified on the command line.
 
 ``` yaml $(az)
 az:
-  extensions: {file_name}-{version}
+  extensions: {name}
   package-name: azure-mgmt-{file_name}
   namespace: azure.mgmt.{file_name}
   client-subscription-bound: false
@@ -102,8 +129,8 @@ az:
 
 extension-mode: {extension_mode}
 
-az-output-folder: $(azure-cli-extension-folder)/{file_name}_{version}
-python-sdk-output-folder: "$(az-output-folder)/azext_{file_name}_{version}/vendored_sdks/{file_name}"
+az-output-folder: $(azure-cli-extension-folder)/{name}
+python-sdk-output-folder: "$(az-output-folder)/azext_{name}/vendored_sdks/{file_name}"
 
 directive:
     - from: 
@@ -124,38 +151,6 @@ directive:
           group: {parsed_file_name}-{parsed_file_name}
       set:
           group: {parsed_file_name}
-    - where:
-          command: {file_name} {parsed_file_name} create-{parsed_file_name}
-      set:
-          command: {file_name} {parsed_file_name} create
-    - where:
-          command: {file_name} {parsed_file_name} get-{parsed_file_name}
-      set:
-          command: {file_name} {parsed_file_name} get
-    - where:
-          command: {file_name} {parsed_file_name} list-{parsed_file_name}
-      set:
-          command: {file_name} {parsed_file_name} list
-    - where:
-          command: {file_name} {parsed_file_name} update-{parsed_file_name}
-      set:
-          command: {file_name} {parsed_file_name} update
-    - where:
-          command: {file_name} {parsed_file_name} add-{parsed_file_name}
-      set:
-          command: {file_name} {parsed_file_name} add
-    - where:
-          command: {file_name} {parsed_file_name} set-{parsed_file_name}
-      set:
-          command: {file_name} {parsed_file_name} set
-    - where:
-          command: {file_name} {parsed_file_name} show-{parsed_file_name}
-      set:
-          command: {file_name} {parsed_file_name} show
-    - where:
-          command: {file_name} {parsed_file_name} delete-{parsed_file_name}
-      set:
-          command: {file_name} {parsed_file_name} delete
     - where:
           command: (.*)(?:(create|get|list|update|add|set|show|delete)-)(.*)
       set:
@@ -209,5 +204,6 @@ def write_to(file, config):
         f.write(config)
 
 
-# generate_extension_from_open_api_description(version='v1_0')
-generate_extension_from_open_api_description(version='beta')
+if __name__ == '__main__':
+    version = 'v1_0' or sys.argv[1]
+    generate_extension_from_open_api_description(version)

--- a/build_scripts/generate_extensions.py
+++ b/build_scripts/generate_extensions.py
@@ -154,7 +154,7 @@ directive:
     - where:
           command: (.*)(?:(create|get|list|update|add|set|show|delete)-)(.*)
       set:
-          command: $1 $3 $2
+          command: $1$3 $2
 
 
 modelerfour:


### PR DESCRIPTION
## Overview

Renames all `verb-noun` commands to follow the `noun` `verb` semantic. eg  `mgc applications application create-extension-property` to  `mgc applications application extension-property create`.

### Demo

![image](https://user-images.githubusercontent.com/40166690/134181885-3b93cfec-eedd-4464-abff-59cd46c5dce9.png)


### Notes

N/A

## Testing Instructions

* Pull these changes
* Generate extensions using the new script
* Run `mgc -h` on any workload
* Observe that all `verb-noun` commands have been renamed to `noun` `verb` pattern

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-cli/pull/194)

Closes #154 